### PR TITLE
fix: quick fix (add 2s wait after history request.)

### DIFF
--- a/src/Kbot.Common/Api/KrakenApi.cs
+++ b/src/Kbot.Common/Api/KrakenApi.cs
@@ -63,6 +63,11 @@ public sealed class KrakenApi(ILogger<KrakenApi> logger, IOptions<Secrets> secre
                 { "API-Key", secrets.Value.ApiKey },
                 { "API-Sign", signature }
             }, jsonBody);
+            if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
+            {
+                logger.LogWarning("Rate limit exceeded. Please try again later.");
+                return null;
+            }
             response.EnsureSuccessStatusCode();
 
             var content = await response.Content.ReadAsStringAsync();

--- a/src/Kbot.Common/Api/KrakenClient.cs
+++ b/src/Kbot.Common/Api/KrakenClient.cs
@@ -141,6 +141,7 @@ public sealed class KrakenClient(ILogger<KrakenClient> logger, KrakenApi api) : 
             offset += 50;
             if (fetchAll && closedOrders.Count >= 50 && offset < closedOrders.Count)
             {
+                Task.Delay(2000).Wait(); // Kraken API History limit is 1 request per 2 seconds
                 var next = await GetClosedOrders(fetchAll: true, offset: offset, start: start, end: end);
                 if (next != null)
                 {

--- a/src/Kbot.Common/Helpers/CsvWriter.cs
+++ b/src/Kbot.Common/Helpers/CsvWriter.cs
@@ -1,5 +1,0 @@
-namespace Kbot.Common.Helpers;
-public class CsvWriter
-{
-
-}

--- a/src/Kbot.Common/Helpers/DateTimeExtension.cs
+++ b/src/Kbot.Common/Helpers/DateTimeExtension.cs
@@ -1,5 +1,0 @@
-namespace Kbot.Common.Helpers;
-public static class DateTimeExtension
-{
-
-}


### PR DESCRIPTION
Dirty quick fix.

The issue about ratelimiting would require a better approach. See Issue #13 