### PR TITLE
test: P1-01 gate the live-trading tests (C-1)

### DIFF
--- a/.runsettings
+++ b/.runsettings
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Default run settings for Kbot.sln.
+
+  `dotnet test` must never place a real order or send real mail. Tests that talk to the live
+  Kraken exchange, an SMTP server or any other network endpoint are tagged
+  [TestCategory("LiveExchange")] (writes: orders and mail) or [TestCategory("LiveApi")]
+  (reads that need live credentials or network) and are excluded here by default.
+
+  See the "Running the tests" section of README.md for how to run them deliberately.
+
+  test/Directory.Build.props applies this file only when no filter was passed on the command
+  line, so an explicit filter replaces the one below instead of being ANDed with it. The
+  LiveExchange tests therefore also call LiveGuard.RequireOptIn() at runtime, which refuses to
+  run them unless KBOT_ALLOW_LIVE_TRADING=1 (see test/Shared/LiveGuard.cs).
+-->
+<RunSettings>
+  <RunConfiguration>
+    <TestCaseFilter>TestCategory!=LiveExchange&amp;TestCategory!=LiveApi</TestCaseFilter>
+  </RunConfiguration>
+</RunSettings>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Do not share your api keys and any privat details!
 3. [Installation](#installation)
 5. [Miscellaneous](#miscellaneous)
     - [Tipps](#tipps)
+    - [Running the tests](#running-the-tests)
     - [Contributing](#contributing)
     - [Bug Report](#bug-report)
 6. [Donation](#donation)
@@ -66,17 +67,28 @@ Please have a look at the wiki [https://github.com/Zuricos/dotnet-kraken-dca-bot
 Create a Subaccount for the DCA and create the api keys for it. If you want to trade without the bot intercept your trading wallet and use the money which is designed for trading.
 -> See [https://docs.kraken.com/api/docs/rest-api/create-subaccount](https://docs.kraken.com/api/docs/rest-api/create-subaccount)
 
+### Running the tests
+`dotnet test Kbot.sln` runs only the hermetic tests and touches neither Kraken nor your mailbox.
+
+The tests that do are tagged `[TestCategory("LiveExchange")]` (they place **real orders with real
+money** and send **real mail**) or `[TestCategory("LiveApi")]` (read-only, but they need live api
+credentials or network). Both categories are excluded by [.runsettings](.runsettings). Running them
+takes an explicit opt-in as well, so a stray filter cannot arm them:
+
+```bash
+KBOT_ALLOW_LIVE_TRADING=1 dotnet test Kbot.sln --filter "TestCategory=LiveExchange"
+```
+
+Without that environment variable the live tests report as skipped. Only opt in against an account
+you are willing to trade on — the order tests buy bitcoin and cancel it again, and a cancel can
+fail.
+
 ### Project documentation
 - [REVIEW.md](REVIEW.md) — full code review of the repository (2026-08-21)
 - [docs/ROADMAP.md](docs/ROADMAP.md) — remediation roadmap: phases, dependencies, branch-per-fix plan
 - [docs/HANDOFF.md](docs/HANDOFF.md) — the wave currently being worked on, with status board
 - [docs/plans/](docs/plans/) — one implementation plan per finding
 - [FUTURE_FEATURES.md](FUTURE_FEATURES.md) — proposed features and their prerequisites
-
-> ⚠️ Some tests in this repository currently place **real orders on live Kraken** and send real
-> mail. Do not run `dotnet test` with valid credentials configured until the test-gating fix
-> ([docs/plans/p1-01-c1-gate-live-trading-tests.md](docs/plans/p1-01-c1-gate-live-trading-tests.md))
-> has been merged.
 
 ### Contributing
 Contributions are welcome! Just reach out to me over an issue or the like.

--- a/src/Kbot.Common/Api/KrakenApi.cs
+++ b/src/Kbot.Common/Api/KrakenApi.cs
@@ -14,8 +14,8 @@ public sealed class KrakenApi : IDisposable
 {
   private static readonly Uri BaseAddress = new("https://api.kraken.com");
 
-  private readonly ILogger<KrakenApi> logger;
-  private readonly IOptions<Secrets> secrets;
+  private readonly ILogger<KrakenApi> _logger;
+  private readonly IOptions<Secrets> _secrets;
   private readonly string _apiVersion = "0";
   private readonly HttpClient _httpClient;
 
@@ -36,8 +36,8 @@ public sealed class KrakenApi : IDisposable
 
   private KrakenApi(ILogger<KrakenApi> logger, IOptions<Secrets> secrets, HttpClient httpClient)
   {
-    this.logger = logger;
-    this.secrets = secrets;
+    _logger = logger;
+    _secrets = secrets;
     _httpClient = httpClient;
   }
 
@@ -66,12 +66,12 @@ public sealed class KrakenApi : IDisposable
     }
     catch (HttpRequestException e)
     {
-      logger.LogError("Request error occurred: {Message}", e.Message);
+      _logger.LogError("Request error occurred: {Message}", e.Message);
       return null;
     }
     catch (Exception e)
     {
-      logger.LogError("An unexpected error occurred: {Message}", e.Message);
+      _logger.LogError("An unexpected error occurred: {Message}", e.Message);
       return null;
     }
   }
@@ -84,7 +84,7 @@ public sealed class KrakenApi : IDisposable
     try
     {
       var urlPath = $"/{_apiVersion}/private/{method}";
-      var s = secrets.Value.ApiKey;
+      var s = _secrets.Value.ApiKey;
       // Add nonce
       var nonce = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
       body.Add("nonce", nonce);
@@ -95,14 +95,14 @@ public sealed class KrakenApi : IDisposable
         urlPath,
         new Dictionary<string, object>
         {
-          { "API-Key", secrets.Value.ApiKey },
+          { "API-Key", _secrets.Value.ApiKey },
           { "API-Sign", signature },
         },
         jsonBody
       );
       if (response.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
       {
-        logger.LogWarning("Rate limit exceeded. Please try again later.");
+        _logger.LogWarning("Rate limit exceeded. Please try again later.");
         return null;
       }
       response.EnsureSuccessStatusCode();
@@ -112,12 +112,12 @@ public sealed class KrakenApi : IDisposable
     }
     catch (HttpRequestException e)
     {
-      logger.LogError("Request error occurred: {Message}", e.Message);
+      _logger.LogError("Request error occurred: {Message}", e.Message);
       return null;
     }
     catch (Exception e)
     {
-      logger.LogError("An unexpected error occurred in QueryPrivateAsync: {Message}", e.Message);
+      _logger.LogError("An unexpected error occurred in QueryPrivateAsync: {Message}", e.Message);
       return null;
     }
   }
@@ -150,7 +150,7 @@ public sealed class KrakenApi : IDisposable
     Buffer.BlockCopy(message, 0, combinedMessage, 0, message.Length);
     Buffer.BlockCopy(shaSum, 0, combinedMessage, message.Length, shaSum.Length);
 
-    byte[] secretBytes = Convert.FromBase64String(secrets.Value.ApiSecret);
+    byte[] secretBytes = Convert.FromBase64String(_secrets.Value.ApiSecret);
     using var hmac = new HMACSHA512(secretBytes);
     var macSum = hmac.ComputeHash(combinedMessage);
     return Convert.ToBase64String(macSum);

--- a/src/Kbot.Common/Api/KrakenApi.cs
+++ b/src/Kbot.Common/Api/KrakenApi.cs
@@ -10,13 +10,36 @@ using Microsoft.Extensions.Options;
 
 namespace Kbot.Common.Api;
 
-public sealed class KrakenApi(ILogger<KrakenApi> logger, IOptions<Secrets> secrets) : IDisposable
+public sealed class KrakenApi : IDisposable
 {
+  private static readonly Uri BaseAddress = new("https://api.kraken.com");
+
+  private readonly ILogger<KrakenApi> logger;
+  private readonly IOptions<Secrets> secrets;
   private readonly string _apiVersion = "0";
-  private readonly HttpClient _httpClient = new()
+  private readonly HttpClient _httpClient;
+
+  public KrakenApi(ILogger<KrakenApi> logger, IOptions<Secrets> secrets)
+    : this(logger, secrets, new HttpClient { BaseAddress = BaseAddress }) { }
+
+  /// <summary>
+  /// Test seam: lets a stub <see cref="HttpMessageHandler"/> stand in for the real transport, so
+  /// the shape of a signed request can be asserted without reaching Kraken. Replacing the
+  /// hand-built <see cref="HttpClient"/> with IHttpClientFactory is tracked separately (P4-03).
+  /// </summary>
+  internal KrakenApi(
+    ILogger<KrakenApi> logger,
+    IOptions<Secrets> secrets,
+    HttpMessageHandler handler
+  )
+    : this(logger, secrets, new HttpClient(handler) { BaseAddress = BaseAddress }) { }
+
+  private KrakenApi(ILogger<KrakenApi> logger, IOptions<Secrets> secrets, HttpClient httpClient)
   {
-    BaseAddress = new Uri("https://api.kraken.com"),
-  };
+    this.logger = logger;
+    this.secrets = secrets;
+    _httpClient = httpClient;
+  }
 
   public void Dispose()
   {

--- a/src/Kbot.Common/Kbot.Common.csproj
+++ b/src/Kbot.Common/Kbot.Common.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <!-- Lets the test project reach the internal API surface and the HttpMessageHandler seam. -->
+    <InternalsVisibleTo Include="Kbot.Common.Test" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Options" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,0 +1,22 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+
+  <!--
+    Apply the repo-root .runsettings, whose category filter keeps the LiveExchange / LiveApi tests
+    out of a plain `dotnet test`.
+
+    Only when no filter was passed on the command line: vstest ANDs a command-line filter with the
+    one from a settings file, which would reduce a run filtered to TestCategory=LiveExchange to an
+    empty test set. A command-line filter arrives here as the global property VSTestTestCaseFilter,
+    so an explicit filter takes the settings file out of the picture and replaces it. What protects
+    the live tests in that case is the runtime opt-in check in Shared/LiveGuard.cs.
+  -->
+  <PropertyGroup Condition="'$(VSTestTestCaseFilter)' == ''">
+    <RunSettingsFilePath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../.runsettings'))</RunSettingsFilePath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Shared/LiveGuard.cs" Link="LiveGuard.cs" />
+    <Using Include="Kbot.Testing" />
+  </ItemGroup>
+</Project>

--- a/test/Kbot.Common.Test/HolidayServiceTest.cs
+++ b/test/Kbot.Common.Test/HolidayServiceTest.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 namespace Kbot.Common.Test;
 
 [TestClass]
+[TestCategory("LiveApi")]
 public class HolidayServiceTest
 {
   private IServiceProvider _serviceProvider = null!;

--- a/test/Kbot.Common.Test/KrakenApiRequestShapeTest.cs
+++ b/test/Kbot.Common.Test/KrakenApiRequestShapeTest.cs
@@ -1,0 +1,185 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Kbot.Common.Api;
+using Kbot.Common.Dtos;
+using Kbot.Common.Enums;
+using Kbot.Common.Options;
+using Microsoft.Extensions.Logging.Abstractions;
+using MsOptions = Microsoft.Extensions.Options.Options;
+
+namespace Kbot.Common.Test;
+
+/// <summary>
+/// Covers the request that <see cref="ApiTestPublic.TestSendAndCancelBuyOrder"/> used to verify by
+/// actually buying bitcoin: an AddOrder call is asserted here against a stub transport, so the
+/// signed request shape is checked without any network access or funds at risk.
+/// </summary>
+[TestClass]
+public class KrakenApiRequestShapeTest
+{
+  private const string ApiKey = "test-api-key";
+  private static readonly string ApiSecret = Convert.ToBase64String(
+    Encoding.UTF8.GetBytes("test-api-secret")
+  );
+
+  private static readonly string TickerResponse = JsonSerializer.Serialize(
+    new
+    {
+      error = Array.Empty<string>(),
+      result = new Dictionary<string, object>
+      {
+        ["XBTCHF"] = new
+        {
+          a = new[] { "50123.40000", "1", "1.000" },
+          b = new[] { "50100.10000", "2", "2.000" },
+          c = new[] { "50110.00000", "0.00100000" },
+          v = new[] { "10.00000000", "20.00000000" },
+          p = new[] { "50000.00000", "50050.00000" },
+          t = new[] { 100, 200 },
+          l = new[] { "49000.00000", "48000.00000" },
+          h = new[] { "51000.00000", "52000.00000" },
+          o = "50000.00000",
+        },
+      },
+    }
+  );
+
+  private static readonly string AddOrderResponse = JsonSerializer.Serialize(
+    new
+    {
+      error = Array.Empty<string>(),
+      result = new
+      {
+        txid = new[] { "OAV6BB-Q2SHQ-XSCJPG" },
+        descr = new { order = "buy 0.00005000 XBTCHF @ limit 50000.0" },
+      },
+    }
+  );
+
+  [TestMethod]
+  public async Task SendOrder_SignsAndSerializesTheRequest()
+  {
+    var handler = new RecordingHandler(AddOrderResponse);
+    var api = new KrakenApi(
+      NullLogger<KrakenApi>.Instance,
+      MsOptions.Create(new Secrets { ApiKey = ApiKey, ApiSecret = ApiSecret }),
+      handler
+    );
+    using var client = new KrakenClient(NullLogger<KrakenClient>.Instance, api);
+
+    var accepted = await client.SendOrder(
+      new OrderRequest
+      {
+        Pair = "XBTCHF",
+        Type = BuyOrSell.Buy,
+        OrderType = OrderType.Limit,
+        Price = 50_000.04,
+        Volume = 0.00005,
+        OrderId = "test-order-id",
+      }
+    );
+
+    Assert.IsTrue(accepted, "The stubbed success response should be reported as accepted.");
+    Assert.IsNotNull(handler.Request, "No request reached the transport.");
+    Assert.AreEqual(HttpMethod.Post, handler.Request.Method);
+    Assert.AreEqual("/0/private/AddOrder", handler.Request.RequestUri!.AbsolutePath);
+    Assert.AreEqual("https://api.kraken.com", handler.Request.RequestUri.GetLeftPart(UriPartial.Authority));
+
+    var body = JsonNode.Parse(handler.Body!)!.AsObject();
+    Assert.AreEqual("XBTCHF", (string?)body["pair"]);
+    Assert.AreEqual("buy", (string?)body["type"]);
+    Assert.AreEqual("limit", (string?)body["ordertype"]);
+    Assert.AreEqual(0.00005, (double?)body["volume"]);
+    Assert.AreEqual(50_000.0, (double?)body["price"], "Price is rounded to one decimal.");
+    Assert.AreEqual("test-order-id", (string?)body["cl_ord_id"]);
+    Assert.IsTrue(body.ContainsKey("nonce"), "The request must carry a nonce.");
+  }
+
+  [TestMethod]
+  public async Task SendOrder_AuthenticatesWithAKeyAndAMatchingSignature()
+  {
+    var handler = new RecordingHandler(AddOrderResponse);
+    var api = new KrakenApi(
+      NullLogger<KrakenApi>.Instance,
+      MsOptions.Create(new Secrets { ApiKey = ApiKey, ApiSecret = ApiSecret }),
+      handler
+    );
+    using var client = new KrakenClient(NullLogger<KrakenClient>.Instance, api);
+
+    await client.SendOrder(
+      new OrderRequest
+      {
+        Pair = "XBTCHF",
+        Type = BuyOrSell.Buy,
+        OrderType = OrderType.Limit,
+        Price = 50_000.0,
+        Volume = 0.00005,
+      }
+    );
+
+    var headers = handler.Request!.Content!.Headers;
+    Assert.AreEqual(ApiKey, headers.GetValues("API-Key").Single());
+
+    var nonce = (long)JsonNode.Parse(handler.Body!)!["nonce"]!;
+    Assert.AreEqual(
+      ExpectedSignature("/0/private/AddOrder", handler.Body!, nonce),
+      headers.GetValues("API-Sign").Single(),
+      "API-Sign must be the HMAC-SHA512 of the url path and the SHA-256 of nonce plus body."
+    );
+  }
+
+  [TestMethod]
+  public async Task GetCurrentCryptoPrice_QueriesThePublicTickerWithoutCredentials()
+  {
+    var handler = new RecordingHandler(TickerResponse);
+    var api = new KrakenApi(
+      NullLogger<KrakenApi>.Instance,
+      MsOptions.Create(new Secrets()),
+      handler
+    );
+    using var client = new KrakenClient(NullLogger<KrakenClient>.Instance, api);
+
+    var price = await client.GetCurrentCryptoPrice("XBTCHF");
+
+    Assert.AreEqual(HttpMethod.Get, handler.Request!.Method);
+    Assert.AreEqual("/0/public/Ticker", handler.Request.RequestUri!.AbsolutePath);
+    Assert.AreEqual("pair=XBTCHF", handler.Request.RequestUri.Query.TrimStart('?'));
+    Assert.IsNull(handler.Request.Content, "A public query must not carry a signed body.");
+    // Only that a price came back, not its value: the parse still runs under the current culture,
+    // and pinning it to invariant culture is P2-02.
+    Assert.AreNotEqual(0.0, price, "The ask price should have been parsed off the response.");
+  }
+
+  private static string ExpectedSignature(string urlPath, string jsonBody, long nonce)
+  {
+    var shaSum = SHA256.HashData(Encoding.UTF8.GetBytes(nonce.ToString() + jsonBody));
+    var path = Encoding.UTF8.GetBytes(urlPath);
+    using var hmac = new HMACSHA512(Convert.FromBase64String(ApiSecret));
+    return Convert.ToBase64String(hmac.ComputeHash([.. path, .. shaSum]));
+  }
+
+  /// <summary>
+  /// Captures the single request it is given and answers it from canned content.
+  /// </summary>
+  private sealed class RecordingHandler(string responseContent) : HttpMessageHandler
+  {
+    internal HttpRequestMessage? Request { get; private set; }
+    internal string? Body { get; private set; }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+      HttpRequestMessage request,
+      CancellationToken cancellationToken
+    )
+    {
+      Request = request;
+      Body =
+        request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+      return new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+      {
+        Content = new StringContent(responseContent, Encoding.UTF8, "application/json"),
+      };
+    }
+  }
+}

--- a/test/Kbot.Common.Test/KrakenApiRequestShapeTest.cs
+++ b/test/Kbot.Common.Test/KrakenApiRequestShapeTest.cs
@@ -85,7 +85,10 @@ public class KrakenApiRequestShapeTest
     Assert.IsNotNull(handler.Request, "No request reached the transport.");
     Assert.AreEqual(HttpMethod.Post, handler.Request.Method);
     Assert.AreEqual("/0/private/AddOrder", handler.Request.RequestUri!.AbsolutePath);
-    Assert.AreEqual("https://api.kraken.com", handler.Request.RequestUri.GetLeftPart(UriPartial.Authority));
+    Assert.AreEqual(
+      "https://api.kraken.com",
+      handler.Request.RequestUri.GetLeftPart(UriPartial.Authority)
+    );
 
     var body = JsonNode.Parse(handler.Body!)!.AsObject();
     Assert.AreEqual("XBTCHF", (string?)body["pair"]);
@@ -174,8 +177,9 @@ public class KrakenApiRequestShapeTest
     )
     {
       Request = request;
-      Body =
-        request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+      Body = request.Content is null
+        ? null
+        : await request.Content.ReadAsStringAsync(cancellationToken);
       return new HttpResponseMessage(System.Net.HttpStatusCode.OK)
       {
         Content = new StringContent(responseContent, Encoding.UTF8, "application/json"),

--- a/test/Kbot.Common.Test/KrakenApiTest.cs
+++ b/test/Kbot.Common.Test/KrakenApiTest.cs
@@ -35,6 +35,7 @@ public class ApiTestPublic
   }
 
   [TestMethod]
+  [TestCategory("LiveApi")]
   public async Task TestQueryTicker()
   {
     var client = _serviceProvider.GetRequiredService<KrakenClient>();
@@ -43,6 +44,7 @@ public class ApiTestPublic
   }
 
   [TestMethod]
+  [TestCategory("LiveApi")]
   public async Task TestQueryBalance()
   {
     var client = _serviceProvider.GetRequiredService<KrakenClient>();
@@ -53,8 +55,10 @@ public class ApiTestPublic
   }
 
   [TestMethod]
+  [TestCategory("LiveExchange")]
   public async Task TestSendAndCancelBuyOrder()
   {
+    LiveGuard.RequireOptIn();
     var client = _serviceProvider.GetRequiredService<KrakenClient>();
     var currentPrice = await client.GetCurrentCryptoPrice("XBTCHF");
     var cl_ord_id = $"test-{DateTime.UtcNow:yyyyMMddHHmm}";
@@ -80,6 +84,7 @@ public class ApiTestPublic
   }
 
   [TestMethod]
+  [TestCategory("LiveApi")]
   public async Task TestQueryClosedOrders()
   {
     var client = _serviceProvider.GetRequiredService<KrakenClient>();
@@ -90,6 +95,7 @@ public class ApiTestPublic
   }
 
   [TestMethod]
+  [TestCategory("LiveApi")]
   public async Task TestQueryAllClosedOrders()
   {
     var client = _serviceProvider.GetRequiredService<KrakenClient>();

--- a/test/Kbot.DcaService.Test/DcaWorkerTest.cs
+++ b/test/Kbot.DcaService.Test/DcaWorkerTest.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging;
 namespace Kbot.DcaService.Test;
 
 [TestClass]
+[TestCategory("LiveExchange")]
 public class DcaWorkerTest
 {
   private IServiceProvider _serviceProvider = null!;
@@ -19,6 +20,7 @@ public class DcaWorkerTest
   [TestInitialize]
   public void Setup()
   {
+    LiveGuard.RequireOptIn();
     var builder = Host.CreateApplicationBuilder();
     builder.Environment.EnvironmentName = "Development";
 

--- a/test/Kbot.MailService.Test/MailGenereateTest.cs
+++ b/test/Kbot.MailService.Test/MailGenereateTest.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging;
 namespace Kbot.MailService.Test;
 
 [TestClass]
+[TestCategory("LiveExchange")]
 public class MailGenerateTest
 {
   private IServiceProvider _serviceProvider = null!;
@@ -20,6 +21,7 @@ public class MailGenerateTest
   [TestInitialize]
   public void Setup()
   {
+    LiveGuard.RequireOptIn();
     var builder = Host.CreateApplicationBuilder();
     builder.Environment.EnvironmentName = "Development";
 

--- a/test/Kbot.MailService.Test/ReportContentTest.cs
+++ b/test/Kbot.MailService.Test/ReportContentTest.cs
@@ -111,7 +111,9 @@ public class ReportContentTest
     ];
 
     using var reader = new StreamReader(aggregated.ToCsv());
-    var lines = reader.ReadToEnd().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+    var lines = reader
+      .ReadToEnd()
+      .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
 
     Assert.AreEqual("Date,Volume,Price,Crypto,Fiat,OrderType,Fee", lines[0]);
     Assert.AreEqual(aggregated.Count + 1, lines.Length);

--- a/test/Kbot.MailService.Test/ReportContentTest.cs
+++ b/test/Kbot.MailService.Test/ReportContentTest.cs
@@ -1,0 +1,147 @@
+using Kbot.Common.Enums;
+using Kbot.Common.Models;
+using Kbot.MailService.Models;
+using Kbot.MailService.Options;
+using Kbot.MailService.Utility;
+
+namespace Kbot.MailService.Test;
+
+/// <summary>
+/// Covers what <see cref="MailGenerateTest"/> only ever proved by sending a real mail: that the
+/// report bodies and the csv attachment are built from the orders they are given. Assertions stay
+/// on structure and content rather than number formatting, which is culture-dependent until P2-02.
+/// </summary>
+[TestClass]
+public class ReportContentTest
+{
+  private static readonly MailOptions Options = new()
+  {
+    CryptoPair = "XXBTZCHF",
+    Crypto = "BTC",
+    Fiat = "CHF",
+    HistoryStartDate = "2024-01-01",
+  };
+
+  private static List<Order> TwoOrders() =>
+    [
+      NewOrder("O-FIRST", new DateTimeOffset(2026, 8, 20, 6, 0, 0, TimeSpan.Zero)),
+      NewOrder("O-SECOND", new DateTimeOffset(2026, 8, 20, 18, 0, 0, TimeSpan.Zero)),
+    ];
+
+  [TestMethod]
+  public void GenerateDailyWelcome_NamesTheAmountBoughtAndTheCurrencies()
+  {
+    var html = HtmlService.GenerateDailyWelcome(TwoOrders(), Options);
+
+    StringAssert.Contains(html, "last 24 hours");
+    StringAssert.Contains(html, "sats", "A BTC report reports the volume in sats.");
+    StringAssert.Contains(html, "CHF");
+  }
+
+  [TestMethod]
+  public void GenerateDailyWelcome_ReportsAnAltcoinInItsOwnUnit()
+  {
+    var html = HtmlService.GenerateDailyWelcome(TwoOrders(), Options with { Crypto = "ETH" });
+
+    StringAssert.Contains(html, "ETH");
+    Assert.IsFalse(html.Contains("sats"), "Only BTC is reported in sats.");
+  }
+
+  [TestMethod]
+  public void GenerateDailyTableFromOrders_EmitsOneRowPerOrder()
+  {
+    var orders = TwoOrders();
+
+    var html = HtmlService.GenerateDailyTableFromOrders(orders, Options);
+
+    Assert.AreEqual(
+      orders.Count + 1,
+      html.Split("<tr").Length - 1,
+      "Expected a header row plus one row per order."
+    );
+    foreach (var order in orders)
+    {
+      StringAssert.Contains(html, order.OrderId);
+    }
+    StringAssert.Contains(html, "2026-08-20 06:00:00Z", "Timestamps are written in UTC.");
+  }
+
+  [TestMethod]
+  public void GenerateDailySummary_ListsEverySummaryLine()
+  {
+    var html = HtmlService.GenerateDailySummary(TwoOrders(), lastAveragePrice: 49000, Options);
+
+    string[] labels =
+    [
+      "Investments",
+      "Total Costs",
+      "Total Fees",
+      "Average Price",
+      "Price Increase",
+    ];
+    foreach (var label in labels)
+    {
+      StringAssert.Contains(html, label);
+    }
+  }
+
+  [TestMethod]
+  public void ToCsv_WritesAHeaderAndOneLinePerAggregatedOrder()
+  {
+    List<AggregatedOrder> aggregated =
+    [
+      new()
+      {
+        Date = new DateTimeOffset(2026, 8, 20, 0, 0, 0, TimeSpan.Zero),
+        Price = 50000,
+        Volume = 0.001,
+        Pair = "XBTCHF",
+        OrderType = "limit",
+        Fee = 0.25,
+      },
+      new()
+      {
+        Date = new DateTimeOffset(2026, 8, 21, 0, 0, 0, TimeSpan.Zero),
+        Price = 51000,
+        Volume = 0.002,
+        Pair = "ETHCHF",
+        OrderType = "limit",
+        Fee = 0.5,
+      },
+    ];
+
+    using var reader = new StreamReader(aggregated.ToCsv());
+    var lines = reader.ReadToEnd().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+    Assert.AreEqual("Date,Volume,Price,Crypto,Fiat,OrderType,Fee", lines[0]);
+    Assert.AreEqual(aggregated.Count + 1, lines.Length);
+    Assert.AreEqual(7, lines[1].Split(',').Length);
+    StringAssert.Contains(lines[1], "Bitcoin", "XBT is spelled out in the report.");
+    StringAssert.Contains(lines[1], "CHF");
+    StringAssert.Contains(lines[2], "ETH");
+  }
+
+  [TestMethod]
+  public void ToCsv_RewindsTheStreamSoItCanBeAttached()
+  {
+    var csv = new List<AggregatedOrder>().ToCsv();
+
+    Assert.AreEqual(0, csv.Position);
+    Assert.IsGreaterThan(0, csv.Length, "The header alone should have been written.");
+  }
+
+  private static Order NewOrder(string orderId, DateTimeOffset closedAt) =>
+    new()
+    {
+      OrderId = orderId,
+      Status = OrderStatus.Closed,
+      CloseTimeStamp = closedAt,
+      Pair = "XXBTZCHF",
+      Type = BuyOrSell.Buy,
+      OrderType = OrderType.Limit,
+      Price = 50000,
+      Volume = 0.001,
+      Cost = 50,
+      Fee = 0.13,
+    };
+}

--- a/test/Shared/LiveGuard.cs
+++ b/test/Shared/LiveGuard.cs
@@ -1,0 +1,26 @@
+namespace Kbot.Testing;
+
+/// <summary>
+/// Opt-in gate for tests that hit the live Kraken exchange or send real mail.
+/// The category filter in <c>.runsettings</c> keeps them out of a plain <c>dotnet test</c> run;
+/// this guard makes sure an explicit <c>--filter</c> cannot arm them by accident either.
+/// </summary>
+internal static class LiveGuard
+{
+  private const string OptInVariable = "KBOT_ALLOW_LIVE_TRADING";
+
+  /// <summary>
+  /// Aborts the current test as inconclusive unless the caller opted in by setting
+  /// <c>KBOT_ALLOW_LIVE_TRADING=1</c>. Call this as the first statement of every test that places
+  /// an order or sends mail, or in the <c>[TestInitialize]</c> of a class that only holds such tests.
+  /// </summary>
+  internal static void RequireOptIn()
+  {
+    if (Environment.GetEnvironmentVariable(OptInVariable) != "1")
+    {
+      Assert.Inconclusive(
+        $"Skipped: this test trades real money or sends real mail. Set {OptInVariable}=1 to run it."
+      );
+    }
+  }
+}


### PR DESCRIPTION
Implements [docs/plans/p1-01-c1-gate-live-trading-tests.md](docs/plans/p1-01-c1-gate-live-trading-tests.md) (finding **C-1**, partially **M-25**).

`dotnet test Kbot.sln` placed real buy orders on live Kraken and sent real mail. It no longer does.

## How the gate works

Two independent mechanisms, because either alone has a hole:

1. **[.runsettings](.runsettings)** excludes `TestCategory!=LiveExchange&TestCategory!=LiveApi`, wired in from the new [test/Directory.Build.props](test/Directory.Build.props). A plain `dotnet test` never discovers a live test.
2. **[test/Shared/LiveGuard.cs](test/Shared/LiveGuard.cs)** — `LiveGuard.RequireOptIn()` marks a test inconclusive unless `KBOT_ALLOW_LIVE_TRADING=1`, so a hand-written `--filter` cannot arm one by accident. Linked into all three test projects.

**Worth a reviewer's attention:** the settings file is applied *only when no `--filter` was passed*, via `Condition="'$(VSTestTestCaseFilter)' == ''"`. vstest **ANDs** a command-line filter with the one from a settings file, so wiring it unconditionally turned the plan's own opt-in command into an empty test set (`(TestCategory!=LiveExchange&TestCategory!=LiveApi)&(TestCategory=LiveExchange)` → "No test matches"). With the condition, an explicit filter replaces the default, discovery works, and mechanism 2 is what actually holds the line — which is the role the plan assigns it.

## Categories applied

| Category | Tests |
|---|---|
| `LiveExchange` (writes real money / mail) | `KrakenApiTest.TestSendAndCancelBuyOrder`, all of `DcaWorkerTest`, all of `MailGenerateTest` |
| `LiveApi` (read-only, needs credentials or network) | `TestQueryTicker`, `TestQueryBalance`, `TestQueryClosedOrders`, `TestQueryAllClosedOrders`, all of `HolidayServiceTest` (fetches date.nager.at) |

All five `LiveExchange` tests also call `RequireOptIn()` — in the test body where the class is mixed, in `[TestInitialize]` where the whole class is live (so no host is built and no secrets are read).

## Replacing the value the gated tests used to provide

Gating alone would have left real coverage behind, so both money-spending tests got hermetic replacements:

- **[KrakenApiRequestShapeTest.cs](test/Kbot.Common.Test/KrakenApiRequestShapeTest.cs)** (3 tests) — `KrakenApi` gained an `internal` constructor overload taking an `HttpMessageHandler` (plus `InternalsVisibleTo`), exactly as the plan's scope item 4 allows. A recording stub handler asserts the AddOrder url path, the serialized body (pair, type, ordertype, volume, the one-decimal rounded price, `cl_ord_id`, nonce), the `API-Key` header, and that `API-Sign` equals the HMAC-SHA512 the observed nonce and body imply. A third test covers the public ticker query and asserts it carries no signed body. No network access.
- **[ReportContentTest.cs](test/Kbot.MailService.Test/ReportContentTest.cs)** (6 tests) — the three `MailGenerateTest` methods asserted *nothing*, they only sent mail. This covers the generation instead: BTC reported in sats vs. an altcoin in its own unit, one table row per order plus a header, UTC timestamps, every promised summary line, and the CSV header / line count / spelled-out asset name / rewound stream.

Assertions deliberately avoid number formatting, which is current-culture dependent until **P2-02**.

## Verified

```
dotnet build Kbot.sln                                      # clean, 0 warnings
dotnet test Kbot.sln                                       # 14 passed, 1 pre-existing failure (below)
dotnet test Kbot.sln --list-tests                          # lists only the 15 hermetic tests
dotnet test Kbot.sln --filter "TestCategory=LiveExchange"   # all 5 live tests → Skipped, no opt-in
csharpier check .                                          # clean, 71 files
```

- With user-secrets present on the machine, a plain `dotnet test` places **no** order and sends **no** mail.
- The opt-in path is verified **by inspection only**, per the plan's acceptance criteria — `KBOT_ALLOW_LIVE_TRADING=1` was never set against the funded account. Discovery under that filter *is* proven: all five tests are found and then skipped by the guard, so the env var is the only remaining variable.

### One pre-existing failure, not from this PR

`TimeComputeTest.ComputeTimeUntilNextTopUp_Yesterday` fails (`Expected:<20>. Actual:<21>`) because it is wall-clock dependent and today is the 21st. Confirmed failing identically on untouched `origin/review-and-fix` via a scratch worktree. It is finding **H-12**, owned by **P1-10**, and `TimeComputeTest.cs` is the one file this plan's conflict surface says not to touch. So `dotnet test Kbot.sln` is *safe* but not yet *green*; P1-10 makes it green.

## Deliberately left out

- **`TimeComputeTest.cs` untouched**, including its `LiveApi`-shaped behaviour: it builds a host with `HolidayService`, so the default run still makes one outbound read-only fetch to date.nager.at. Tagging it would collide with **P1-10**; no money or write path is involved.
- **`DcaWorker.FixOrderId` kept** (scope item 6 was conditional): the gated `DcaWorkerTest` still sets it, so it cannot be removed yet. Noted for **P3-02**.
- **`TestSendAndCancelBuyOrder` kept** rather than deleted, now gated. The plan says to replace its *value* with a hermetic test, which the new tests do; keeping the round-trip available behind the opt-in loses nothing and is what acceptance criterion 2 exercises.
- **`LiveGuard.RequireOptIn()` deviates from the plan's snippet**, which reads `Assert.Inconclusive(cond ? null! : "msg")` — `Assert.Inconclusive` always throws, so that form would skip the test even when opted in. Implemented as an `if` on the env var.
- **CI wiring** of the filter → **P1-05** (the `.runsettings` it needs is landed here). Signing/parser/state/validator unit tests and the `Parallelize(Workers = 0)` question → **P3-03**. `IHttpClientFactory` for `KrakenApi` → **P4-03**.

## Follow-up for the maintainer

[docs/HANDOFF.md](docs/HANDOFF.md) §2 rule 1 ("never run the full test suite with credentials configured") goes stale when this merges. Left for the handoff process in §8 rather than edited here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
