### PR TITLE
fix: P1-02 guard the Kraken sentinel call sites (C-2, C-3)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -116,6 +116,11 @@ The DCA worker uses `AskMultiplier = 1.00001` from `stack.env` — *above* ask �
 
 ### C-2 · A failed ticker call returns `0.0`, which the worker trades on
 
+> ✅ **Resolved** by [P1-02](docs/plans/p1-02-c2-c3-guard-worker-sentinels.md), merged as PR #43. The ticker
+> entry is read by value rather than by the requested pair name, the worker skips the cycle on a
+> non-positive price, and the interval computation can no longer yield `Zero`, `Infinity` or `NaN`.
+> The `0.0` sentinel itself survives until P2-01 replaces the protocol.
+
 **Files:** [KrakenClient.cs:52,66](src/Kbot.Common/Api/KrakenClient.cs#L52) · [DcaWorker.cs:66-69](src/Kbot.DcaService/DcaWorker.cs#L66-L69) · [TimeComputeService.cs:64-65](src/Kbot.DcaService/Utility/TimeComputeService.cs#L64-L65)
 
 `GetCurrentCryptoPrice` returns `0.0` on *every* error path — HTTP failure, Kraken error array, and notably `response.Result![pair]` throwing `KeyNotFoundException` when Kraken returns its canonical pair name instead of the requested alias (request `XBTUSD`, get key `XXBTZUSD`). `DcaWorker` never checks the result. The cascade:
@@ -152,6 +157,10 @@ var tickerInfo = response.Result!.Values.Single().Parse();
 ---
 
 ### C-3 · A failed balance call returns `[]`, and the worker indexes it directly
+
+> ✅ **Resolved** by [P1-02](docs/plans/p1-02-c2-c3-guard-worker-sentinels.md), merged as PR #43. The fiat
+> balance is looked up with `TryGetValue`; a missing asset logs the available keys and costs one
+> skipped cycle instead of stopping the host.
 
 **Files:** [KrakenClient.cs:23,36](src/Kbot.Common/Api/KrakenClient.cs#L23) · [DcaWorker.cs:64](src/Kbot.DcaService/DcaWorker.cs#L64)
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -118,6 +118,10 @@ Rules:
 - Stay in scope. Do not fix findings the plan lists as belonging to another plan.
 - Conventional commit messages (test:, fix:, refactor:, ci:, chore:, docs:), one logical change each.
 - Verify with the commands in the plan's Verification section before you finish.
+- Before opening the PR, close the plan out in a final docs: commit on your branch — the plan
+  file's Status row and Resolution section, the §7 status board row, the ROADMAP tables, the
+  REVIEW.md finding callout and any cross-plan note your change makes stale. The exact list is
+  "Closing out a plan" in docs/plans/README.md. Phrase it as already merged.
 - Then open a PR into review-and-fix titled "test: P1-01 gate the live-trading tests (C-1)", body linking
   docs/plans/p1-01-c1-gate-live-trading-tests.md, listing what you verified, and naming anything
   you deliberately left out.
@@ -152,6 +156,10 @@ Rules:
   tests only.
 - Conventional commit messages, one logical change each.
 - Verify with the commands in the plan's Verification section before you finish.
+- Before opening the PR, close the plan out in a final docs: commit on your branch — the plan
+  file's Status row and Resolution section, the §7 status board row, the ROADMAP tables, the
+  REVIEW.md finding callout and any cross-plan note your change makes stale. The exact list is
+  "Closing out a plan" in docs/plans/README.md. Phrase it as already merged.
 - Then open a PR into review-and-fix titled "fix: P1-02 guard the Kraken sentinel call sites (C-2, C-3)",
   body linking the plan file, listing what you verified, and naming anything left out.
 ```
@@ -184,6 +192,10 @@ Rules:
   tests only.
 - Conventional commit messages, one logical change each.
 - Verify with the commands in the plan's Verification section before you finish.
+- Before opening the PR, close the plan out in a final docs: commit on your branch — the plan
+  file's Status row and Resolution section, the §7 status board row, the ROADMAP tables, the
+  REVIEW.md finding callout and any cross-plan note your change makes stale. The exact list is
+  "Closing out a plan" in docs/plans/README.md. Phrase it as already merged.
 - Then open a PR into review-and-fix titled "fix: P1-03 clamp the top-up day and persist state before
   bookkeeping (C-4)", body linking the plan file, listing what you verified, and naming anything
   left out.
@@ -217,6 +229,10 @@ Rules:
   tests only.
 - Conventional commit messages, one logical change each.
 - Verify with the commands in the plan's Verification section before you finish.
+- Before opening the PR, close the plan out in a final docs: commit on your branch — the plan
+  file's Status row and Resolution section, the §7 status board row, the ROADMAP tables, the
+  REVIEW.md finding callout and any cross-plan note your change makes stale. The exact list is
+  "Closing out a plan" in docs/plans/README.md. Phrase it as already merged.
 - Then open a PR into review-and-fix titled "fix: P1-04 worker loop resilience and backoff (C-5)", body
   linking the plan file, listing what you verified, and naming anything left out.
 ```
@@ -244,6 +260,10 @@ Rules:
 - `dotnet test Kbot.sln` is safe by default since P1-01 landed. Never set `KBOT_ALLOW_LIVE_TRADING=1`.
 - Conventional commit messages, one logical change each.
 - Verify with the commands in the plan's Verification section, including the docker build.
+- Before opening the PR, close the plan out in a final docs: commit on your branch — the plan
+  file's Status row and Resolution section, the §7 status board row, the ROADMAP tables, the
+  REVIEW.md finding callout and any cross-plan note your change makes stale. The exact list is
+  "Closing out a plan" in docs/plans/README.md. Phrase it as already merged.
 - Then open a PR into review-and-fix titled "fix: P1-06 move .dockerignore to the repo root and stop copying
   secrets.json (H-4)", body linking the plan file and listing what you verified.
 ```
@@ -278,6 +298,10 @@ Rules:
   tests only.
 - Conventional commit messages, one logical change each.
 - Verify with the commands in the plan's Verification section before you finish.
+- Before opening the PR, close the plan out in a final docs: commit on your branch — the plan
+  file's Status row and Resolution section, the §7 status board row, the ROADMAP tables, the
+  REVIEW.md finding callout and any cross-plan note your change makes stale. The exact list is
+  "Closing out a plan" in docs/plans/README.md. Phrase it as already merged.
 - Then open a PR into review-and-fix titled "fix: P1-07 tighten the options validators (H-10)", body linking
   the plan file, listing what you verified, and naming anything left out.
 ```
@@ -310,6 +334,10 @@ Rules:
 - `dotnet test Kbot.sln` is safe by default since P1-01 landed. Never set `KBOT_ALLOW_LIVE_TRADING=1`.
 - Conventional commit messages, one logical change each.
 - Verify with the commands in the plan's Verification section before you finish.
+- Before opening the PR, close the plan out in a final docs: commit on your branch — the plan
+  file's Status row and Resolution section, the §7 status board row, the ROADMAP tables, the
+  REVIEW.md finding callout and any cross-plan note your change makes stale. The exact list is
+  "Closing out a plan" in docs/plans/README.md. Phrase it as already merged.
 - Then open a PR into review-and-fix titled "fix: P1-08 remove the committed DB password and published
   Postgres port (H-11)", body linking the plan file and listing what you verified.
 ```
@@ -340,6 +368,10 @@ Rules:
   tests only.
 - Conventional commit messages, one logical change each.
 - Verify with the commands in the plan's Verification section before you finish.
+- Before opening the PR, close the plan out in a final docs: commit on your branch — the plan
+  file's Status row and Resolution section, the §7 status board row, the ROADMAP tables, the
+  REVIEW.md finding callout and any cross-plan note your change makes stale. The exact list is
+  "Closing out a plan" in docs/plans/README.md. Phrase it as already merged.
 - Then open a PR into review-and-fix titled "fix: P1-09 stop logging the API secret (M-16)", body linking the
   plan file and listing what you verified.
 ```
@@ -372,6 +404,10 @@ Rules:
   tests only.
 - Conventional commit messages, one logical change each.
 - Verify with the commands in the plan's Verification section, including the de-DE / fr-FR runs.
+- Before opening the PR, close the plan out in a final docs: commit on your branch — the plan
+  file's Status row and Resolution section, the §7 status board row, the ROADMAP tables, the
+  REVIEW.md finding callout and any cross-plan note your change makes stale. The exact list is
+  "Closing out a plan" in docs/plans/README.md. Phrase it as already merged.
 - Then open a PR into review-and-fix titled "fix: P2-02 pin InvariantCulture on every wire value (H-1)", body
   linking the plan file and listing what you verified.
 ```
@@ -392,13 +428,19 @@ Rules:
 - Tests pass under the safe filter
   (applied by default through `.runsettings` since P1-01 landed).
 - PR body links the plan file, lists what was verified, and names anything deliberately left out.
-- Nothing outside the plan's scope changed.
+- Nothing outside the plan's scope changed — **except the close-out docs, which every PR carries**:
+  the plan file's Status row and Resolution section, the §7 status board row, the §4 and §5 entries,
+  the ROADMAP tables, the REVIEW.md finding callout, the plan index, and any cross-plan guidance the
+  merge makes stale. The exact list is
+  [Closing out a plan](plans/README.md#closing-out-a-plan). Write it in the tense that is true after
+  the merge, so `review-and-fix` never needs a follow-up docs commit.
 
 ---
 
 ## 7. Status board
 
-Update this as work lands. `—` = not started.
+Every PR updates its own row, on its own branch, before it is opened — see
+[Closing out a plan](plans/README.md#closing-out-a-plan). `—` = not started.
 
 | Plan | Branch | Status | PR | Merged |
 |---|---|---|---|---|
@@ -448,7 +490,8 @@ Paste this into a new session that has no context at all:
 Work in the repo dotnet-kraken-dca-bot. Read docs/HANDOFF.md — it is a self-contained handoff for
 the first wave of remediation work on this repository. Follow it: check the status board in §7 to
 see what is still open, then either dispatch the ready-to-paste agent prompts in §5, or implement
-one plan yourself.
+one plan yourself. Whichever you do, the plan's PR also carries its own close-out docs — see
+"Closing out a plan" in docs/plans/README.md.
 
 Two hard rules before you touch anything: (1) `dotnet test Kbot.sln` places real buy orders on live
 Kraken and sends real email only if you opt in with KBOT_ALLOW_LIVE_TRADING=1 (P1-01 is merged) — never do; (2) each plan in

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -14,12 +14,13 @@ then follow §8 to produce the next handoff.
 |---|---|
 | Repo | `dotnet-kraken-dca-bot` — a .NET 10 Kraken DCA bot (6 projects: `Kbot.Common`, `Kbot.DcaService`, `Kbot.MailService` + 3 test projects) |
 | What exists | A full code review ([REVIEW.md](../REVIEW.md)), a phased roadmap ([ROADMAP.md](ROADMAP.md)) and 37 branch-sized implementation plans ([plans/](plans/)) |
-| What has been fixed | **Nothing.** All 64 findings are open. This handoff starts the execution. |
-| Branch state | `main` = upstream, untouched. `review-and-fix` = `main` + the review + these docs, and **the integration branch all work merges into**. P1-01 has landed there (`58c2262`); everything else is still open. |
+| What has been fixed | **3 of 64 findings.** C-1 (P1-01) and C-2 / C-3 (P1-02) are merged. The rest are open. |
+| Branch state | `main` = upstream, untouched. `review-and-fix` = `main` + the review + these docs, and **the integration branch all work merges into**. P1-01 (`58c2262`) and P1-02 (#43) have landed there; everything else is still open. |
 
 **The one thing to know:** the review's verdict is *"not safe to run unattended with real money until
 C-1 … C-5 are fixed."* Those five findings are owned by plans **P1-01, P1-02, P1-03, P1-04**. They are
-all in Wave 0 and they are the point of this handoff.
+all in Wave 0 and they are the point of this handoff. C-1, C-2 and C-3 are closed; **C-4 and C-5
+(P1-03, P1-04) are what is left before the bot is safe.**
 
 ---
 
@@ -64,7 +65,7 @@ If you ever see a plan or an older doc say "base on `main`", it is stale — thi
 | # | Plan | Branch | Findings | Effort |
 |---|---|---|---|---|
 | ~~1~~ | ~~[P1-01](plans/p1-01-c1-gate-live-trading-tests.md)~~ ✅ merged | `test/p1-c1-gate-live-trading-tests` | **C-1** | S |
-| 2 | [P1-02](plans/p1-02-c2-c3-guard-worker-sentinels.md) | `fix/p1-c2-c3-guard-worker-sentinels` | **C-2, C-3** | S |
+| ~~2~~ | ~~[P1-02](plans/p1-02-c2-c3-guard-worker-sentinels.md)~~ ✅ merged | `fix/p1-c2-c3-guard-worker-sentinels` | **C-2, C-3** | S |
 | 3 | [P1-03](plans/p1-03-c4-topup-day-clamp-and-state-order.md) | `fix/p1-c4-topup-day-clamp-and-state-order` | **C-4** | S |
 | 4 | [P1-04](plans/p1-04-c5-worker-loop-resilience.md) | `fix/p1-c5-worker-loop-resilience` | **C-5** | S |
 | 5 | [P1-06](plans/p1-06-h4-dockerignore-and-secret-copy.md) | `fix/p1-h4-dockerignore-and-secret-copy` | H-4 | S |
@@ -80,11 +81,14 @@ to have no prerequisites — take it only if capacity is left over.
 
 Development is parallel; **merging** has two ordering constraints, both from shared files:
 
-- `src/Kbot.DcaService/DcaWorker.cs` → merge **P1-02 → P1-03 → P1-04**
-- `src/Kbot.DcaService/Utility/TimeComputeService.cs` → merge **P1-03 → P1-02**
+- `src/Kbot.DcaService/DcaWorker.cs` → merge **P1-02 → P1-03 → P1-04** (P1-02 is merged)
+- `src/Kbot.DcaService/Utility/TimeComputeService.cs` → planned **P1-03 → P1-02**; P1-02 got there
+  first
 
-Combined, a conflict-free merge order for the critical four is: **P1-03 → P1-02 → P1-04** (P1-01 was
-independent and is already merged, which is what makes the suite safe for everyone else).
+The suggested merge order for the critical four was **P1-03 → P1-02 → P1-04**, but P1-02 merged
+first, so **P1-03 and P1-04 build on it** — it is already in `DcaWorker.cs` and
+`TimeComputeService.cs`, and branching from `review-and-fix` picks it up.
+P1-01 was independent and is merged, which is what makes the suite safe for everyone else.
 Each conflict is a small local edit; rebasing is a two-minute job, not a redesign.
 
 ---
@@ -121,7 +125,7 @@ Rules:
 </details>
 
 <details>
-<summary><b>P1-02 · Guard the Kraken sentinel call sites (C-2, C-3)</b></summary>
+<summary><b>P1-02 · Guard the Kraken sentinel call sites (C-2, C-3) — ✅ merged, nothing to do</b></summary>
 
 ```
 Work in the repo dotnet-kraken-dca-bot.
@@ -168,10 +172,11 @@ Branch: git switch -c fix/p1-c4-topup-day-clamp-and-state-order origin/review-an
 Context you need: DefaultTopupDayOfMonth accepts 1-31, but new DateTime(2026, 4, 31) throws. The
 throw happens AFTER a successful order is sent and BEFORE the state is persisted, so the host dies,
 Docker restarts it, the pre-order state is reloaded and it buys again. You are clamping the day and
-reordering the persist. Recommended merge order puts you first among the DcaWorker.cs plans.
+reordering the persist.
 
-Conflict note: P1-02 also edits DcaWorker.cs and TimeComputeService.cs; P1-04 also edits
-DcaWorker.cs. Keep edits local and minimal.
+Conflict note: P1-02 is merged, so review-and-fix already carries its guards in DcaWorker.cs and
+TimeComputeService.cs — the top of InvestmentCycle and ComputeNextInvestmentInterval. Leave them
+alone. P1-04 also edits DcaWorker.cs. Keep edits local and minimal.
 
 Rules:
 - Stay in scope. Do not fix findings the plan lists as belonging to another plan.
@@ -203,8 +208,8 @@ state is an opportunity for an unscheduled buy. You are adding try/catch + expon
 both worker loops (DCA and mail) so transient faults are survived rather than escalated. You are
 NOT fixing the individual throws — other plans own those.
 
-Conflict note: P1-02 and P1-03 also edit src/Kbot.DcaService/DcaWorker.cs; recommended merge order
-puts you last of the three. P2-07 also edits DailyReporter.cs.
+Conflict note: P1-02 is merged into src/Kbot.DcaService/DcaWorker.cs and P1-03 also edits it; you
+merge last of the three. P2-07 also edits DailyReporter.cs.
 
 Rules:
 - Stay in scope. Do not fix findings the plan lists as belonging to another plan.
@@ -264,8 +269,8 @@ tightening the validators, adding safe defaults, and unit-testing every rule (th
 validator coverage today, which is how this survived).
 
 Conflict note: P1-03 also edits BalanceOptions.cs — if it is already merged, leave its
-DefaultTopupDayOfMonth rule alone. P1-02 adds an Enum.IsDefined check on OrderOptions.Type; keep
-one copy.
+DefaultTopupDayOfMonth rule alone. P1-02 already added the Enum.IsDefined check on
+OrderOptions.Type; do not add a second one.
 
 Rules:
 - Stay in scope. Do not fix findings the plan lists as belonging to another plan.
@@ -398,7 +403,7 @@ Update this as work lands. `—` = not started.
 | Plan | Branch | Status | PR | Merged |
 |---|---|---|---|---|
 | P1-01 | `test/p1-c1-gate-live-trading-tests` | ✅ resolved | #42 | `58c2262` (2026-08-22) |
-| P1-02 | `fix/p1-c2-c3-guard-worker-sentinels` | — | | |
+| P1-02 | `fix/p1-c2-c3-guard-worker-sentinels` | ✅ resolved | #43 | via #43 |
 | P1-03 | `fix/p1-c4-topup-day-clamp-and-state-order` | — | | |
 | P1-04 | `fix/p1-c5-worker-loop-resilience` | — | | |
 | P1-06 | `fix/p1-h4-dockerignore-and-secret-copy` | — | | |
@@ -408,6 +413,7 @@ Update this as work lands. `—` = not started.
 | P2-02 | `fix/p2-h1-invariant-culture` | — | | |
 
 **Milestone M1 ("safe to run") is reached when P1-01, P1-02, P1-03 and P1-04 are all merged.**
+P1-01 and P1-02 are merged; **P1-03 and P1-04 are the two still to be written.**
 
 ---
 
@@ -419,7 +425,7 @@ Each merge unlocks specific plans. From [ROADMAP.md](ROADMAP.md) §4:
 |---|---|
 | ✅ P1-01 *(merged)* | **P1-05** (`ci/p1-h3-build-test-lint-pipeline`) — **now ready**; CI could not be wired up before the tests were safe |
 | P1-03 | **P1-10** (`test/p1-h12-deterministic-timecompute-tests`) |
-| P1-02 **and** P1-04 | **P2-01** (`refactor/p2-i1-kraken-result-protocol`) — the highest-value change in the review |
+| ✅ P1-02 *(merged)* **and** P1-04 | **P2-01** (`refactor/p2-i1-kraken-result-protocol`) — the highest-value change in the review; now waiting on P1-04 alone |
 | P1-03 **and** P1-07 | **P2-08** (`refactor/p2-i5-shared-trading-options`) |
 | P1-08 | **P4-06** (`fix/p4-m17-m21-startup-and-healthchecks`) |
 | P1-05 | **P2-09** (`ci/p2-workflow-hardening`) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -140,7 +140,7 @@ merge order matters (see the note below) but their *development* does not.
 | Plan | Branch | Findings |
 |---|---|---|
 | ~~P1-01~~ ✅ merged | `test/p1-c1-gate-live-trading-tests` | C-1 |
-| P1-02 | `fix/p1-c2-c3-guard-worker-sentinels` | C-2, C-3 |
+| ~~P1-02~~ ✅ merged | `fix/p1-c2-c3-guard-worker-sentinels` | C-2, C-3 |
 | P1-03 | `fix/p1-c4-topup-day-clamp-and-state-order` | C-4 |
 | P1-04 | `fix/p1-c5-worker-loop-resilience` | C-5 |
 | P1-06 | `fix/p1-h4-dockerignore-and-secret-copy` | H-4 |
@@ -149,11 +149,11 @@ merge order matters (see the note below) but their *development* does not.
 | P1-09 | `fix/p1-m16-redact-secrets-in-logs` | M-16 |
 | P2-02 | `fix/p2-h1-invariant-culture` | H-1 |
 
-> **`DcaWorker.cs` merge order: P1-02 → P1-03 → P1-04.** Each is a small, local edit; whoever merges
-> second rebases. If you would rather avoid it entirely, run them strictly in that sequence and have
-> one agent hand off to the next.
+> **`DcaWorker.cs` merge order: P1-02 → P1-03 → P1-04.** P1-02 is merged, so P1-03 and P1-04 build
+> on it. Each is a small, local edit; rebasing is a two-minute job.
 >
-> **`TimeComputeService.cs`** is touched by P1-02 (divisor guard) and P1-03 (date clamp) — same note.
+> **`TimeComputeService.cs`** is touched by P1-02 (divisor guard, merged) and P1-03 (date clamp) —
+> same note.
 
 ### Wave 1 — unlocked by Wave 0
 
@@ -161,7 +161,7 @@ merge order matters (see the note below) but their *development* does not.
 |---|---|---|
 | P1-05 | P1-01 | `ci/p1-h3-build-test-lint-pipeline` |
 | P1-10 | P1-03 | `test/p1-h12-deterministic-timecompute-tests` |
-| P2-01 | P1-02 + P1-04 | `refactor/p2-i1-kraken-result-protocol` |
+| P2-01 | ✅ P1-02 + P1-04 (waiting on P1-04) | `refactor/p2-i1-kraken-result-protocol` |
 | P2-03 | P2-02 | `refactor/p2-h2-decimal-money` |
 | P2-08 | P1-03 + P1-07 | `refactor/p2-i5-shared-trading-options` |
 | P2-09 | P1-05 | `ci/p2-workflow-hardening` |
@@ -217,8 +217,8 @@ Every finding in REVIEW.md, with its owning plan. Use this to check nothing was 
 | Finding | Plan | Finding | Plan |
 |---|---|---|---|
 | C-1 ✅ | P1-01 *(merged)* | M-1 | P4-08 |
-| C-2 | P1-02 (→ P2-01) | M-2 | P4-09 |
-| C-3 | P1-02 (→ P2-01) | M-3 | P2-05 |
+| C-2 ✅ | P1-02 *(merged)* (→ P2-01) | M-2 | P4-09 |
+| C-3 ✅ | P1-02 *(merged)* (→ P2-01) | M-3 | P2-05 |
 | C-4 | P1-03 | M-4 | P4-09 |
 | C-5 | P1-04 | M-5 | P4-09 |
 | H-1 | P2-02 | M-6 | P4-09 |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,6 +25,11 @@ more urgent than any of them.
 - Branch from **`review-and-fix`** and PR back into it; `main` stays untouched until the maintainer
   merges the accumulated work. The working protocol is in [plans/README.md](plans/README.md), the
   base-branch details in [HANDOFF.md](HANDOFF.md) §3.
+- **Every PR closes its own plan out**: the tables here, the status board and the REVIEW.md finding
+  are updated on the plan's branch, so this roadmap is accurate the moment a PR merges. The list of
+  what to touch is [Closing out a plan](plans/README.md#closing-out-a-plan). If a merge invalidates
+  guidance written for another plan — a merge order, a conflict note — that gets fixed in the same
+  commit.
 
 ---
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -49,7 +49,7 @@ prompts and the status board.
 |---|---|---|---|
 | **Phase 1 — stop the bleeding** ||||
 | P1-01 ✅ | C-1 | Gate the live-trading tests *(resolved — `58c2262`)* | `test/p1-c1-gate-live-trading-tests` |
-| P1-02 | C-2, C-3 | Guard the Kraken sentinel call sites | `fix/p1-c2-c3-guard-worker-sentinels` |
+| P1-02 ✅ | C-2, C-3 | Guard the Kraken sentinel call sites *(resolved — #43)* | `fix/p1-c2-c3-guard-worker-sentinels` |
 | P1-03 | C-4 | Clamp the top-up day, persist state before bookkeeping | `fix/p1-c4-topup-day-clamp-and-state-order` |
 | P1-04 | C-5 | Worker loop resilience and backoff | `fix/p1-c5-worker-loop-resilience` |
 | P1-05 | H-3 | CI: build, test, format gate | `ci/p1-h3-build-test-lint-pipeline` |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -42,6 +42,65 @@ prompts and the status board.
    > [p1-01-c1-gate-live-trading-tests.md](p1-01-c1-gate-live-trading-tests.md).
 7. **PR title** = plan ID + title (e.g. `fix: P1-02 guard the Kraken sentinel call sites (C-2, C-3)`).
    PR body: link the plan file, list the finding IDs closed, and state what you verified.
+8. **Close the plan out in the same PR** — a final `docs:` commit that marks it resolved everywhere.
+   See [Closing out a plan](#closing-out-a-plan) for the exact list. This is part of the work, not a
+   follow-up: it means nothing has to be corrected on `review-and-fix` after the merge.
+
+## Closing out a plan
+
+Write these updates on your own branch, before opening the PR, and phrase them in the tense that is
+true **after** the merge ("merged as PR #57"), never "PR open" — otherwise every merge needs a second
+docs pass, and a status board that lags behind the branches is how two agents end up doing the same
+plan twice.
+
+One `docs:` commit, six places:
+
+1. **The plan file.** A `**Status**` row at the top of the header table and a `## Resolution` section
+   at the bottom:
+   ```markdown
+   | **Status** | ✅ **Resolved** — merged into `review-and-fix` via PR #NN |
+   ```
+   ```markdown
+   ---
+
+   ## Resolution
+
+   Merged into `review-and-fix` from `<branch>` as PR #NN. **<findings> are closed**: <one sentence
+   on what is no longer possible>.
+
+   What landed:
+
+   - [<file>](../../<path>) — what changed and why. One bullet per scope item, in the plan's order.
+
+   <Anything the scope implied but did not spell out — say why it was necessary.>
+
+   Tests: [<file>](../../<path>) — what they pin down.
+
+   Verified: `dotnet build Kbot.sln -warnaserror` clean, N tests pass under the default filter,
+   `csharpier check .` clean.
+
+   Deliberately not done: <item> → **<owning plan>**.
+
+   Follow-ups unblocked: **<plan>**.
+   ```
+2. **[../HANDOFF.md](../HANDOFF.md)** — the §7 status board row (Status / PR / Merged), the §4 Wave
+   table row, the §5 prompt summary (`— ✅ merged, nothing to do`), and whatever in §1 or §2 the
+   change makes stale (the fixed-findings count, the "what has been fixed" row, a hard rule that no
+   longer applies).
+3. **[../ROADMAP.md](../ROADMAP.md)** — the wave table row, the finding → plan matrix in §6, and the
+   Wave 1 row of anything this unblocks.
+4. **[../../REVIEW.md](../../REVIEW.md)** — a `> ✅ **Resolved** by …` block under each finding
+   heading the plan closes, naming what changed. Leave the finding text itself alone: it is the
+   historical record of why the work happened, not a live status.
+5. **This file** — the plan index row.
+6. **Stale cross-plan guidance.** This is the part a checklist misses. If merging changed the
+   assumptions other plans were written under — a merge order that no longer holds, a conflict note
+   that now describes code already in `review-and-fix`, a check a later plan was told to add that you
+   just added — fix those sentences too, including inside the §5 agent prompts. Marking your own row
+   done while leaving the next agent a stale instruction is worse than not updating anything.
+
+Do not touch a *different* plan's Status, and do not tick criteria you did not meet — say plainly in
+the Resolution section what you left out and which plan owns it.
 
 ## Plan index
 

--- a/docs/plans/p1-02-c2-c3-guard-worker-sentinels.md
+++ b/docs/plans/p1-02-c2-c3-guard-worker-sentinels.md
@@ -2,6 +2,7 @@
 
 |  |  |
 |---|---|
+| **Status** | ✅ **Resolved** — merged into `review-and-fix` via PR #43 |
 | **Findings** | C-2, C-3 |
 | **Phase** | 1 — Stop the bleeding |
 | **Branch** | `fix/p1-c2-c3-guard-worker-sentinels` |
@@ -101,3 +102,48 @@ dotnet build Kbot.sln -warnaserror
 dotnet test Kbot.sln --filter "TestCategory!=LiveExchange&TestCategory!=LiveApi"
 dotnet csharpier check .
 ```
+
+---
+
+## Resolution
+
+Merged into `review-and-fix` from `fix/p1-c2-c3-guard-worker-sentinels` as PR #43.
+**C-2 and C-3 are closed**: no cycle proceeds on a sentinel any more.
+
+What landed:
+
+- [KrakenClient.GetCurrentCryptoPrice](../../src/Kbot.Common/Api/KrakenClient.cs#L43) takes the
+  single ticker entry by value instead of indexing by the requested pair name, so Kraken echoing
+  `XXBTZUSD` for an `XBTUSD` request no longer throws into the `0.0` path. Every failure path names
+  the pair, and an unexpected entry count logs the returned keys. The `0.0` sentinel stays for P2-01.
+- [DcaWorker.InvestmentCycle](../../src/Kbot.DcaService/DcaWorker.cs#L88) guards the balance
+  lookup and the price before any arithmetic, each returning `MaxWaitTime`.
+- [TimeComputeService.ComputeNextInvestmentInterval](../../src/Kbot.DcaService/Utility/TimeComputeService.cs#L58)
+  refuses a non-positive or non-finite balance or cost, returns `TimeSpan.MaxValue` for a
+  non-positive top-up window, and floors an interval that would round down to zero ticks.
+- [OrderOptionsValidator](../../src/Kbot.DcaService/Options/OrderOptions.cs#L17) rejects an
+  out-of-range `Type`, and the worker logs the effective order type once at startup, warning when it
+  is `Market`.
+
+Two knock-on changes this scope implies but the plan did not spell out:
+
+- `TimeSpan.MaxValue` overflows `State.LastInvestmentTime + investmentInterval`, so that addition
+  saturates at `DateTime.MaxValue` and the caller's clamp turns it into `MaxWaitTime`.
+- A freshly loaded state carries `TimeUntilNextTopUp = TimeSpan.Zero`, which the new
+  non-positive-window guard would otherwise turn into *never invest*, so `ExecuteAsync` seeds it
+  before the first cycle.
+
+Tests (all hermetic, over a stubbed `HttpMessageHandler` — no credentials, no network):
+[InvestmentCycleGuardTest.cs](../../test/Kbot.DcaService.Test/InvestmentCycleGuardTest.cs) drives one
+cycle per failure mode plus a healthy counter-test,
+[InvestmentIntervalTest.cs](../../test/Kbot.DcaService.Test/InvestmentIntervalTest.cs) covers the
+degenerate-input matrix, and
+[KrakenApiRequestShapeTest.cs](../../test/Kbot.Common.Test/KrakenApiRequestShapeTest.cs) gained the
+canonical-pair-name parse. `DcaWorker.State` and `InvestmentCycle` became `internal` (plus
+`InternalsVisibleTo`) to make that possible; the real seam extraction is P3-01/P3-02.
+
+Verified: `dotnet build Kbot.sln -warnaserror` clean, 40 tests pass under the default filter,
+`csharpier check .` clean.
+
+Follow-ups: **P2-01** now waits on P1-04 alone. **P1-03** and **P1-04** branch from
+`review-and-fix` after this, since it reached `DcaWorker.cs` and `TimeComputeService.cs` first.

--- a/src/Kbot.Common/Api/KrakenClient.cs
+++ b/src/Kbot.Common/Api/KrakenClient.cs
@@ -50,8 +50,21 @@ public sealed class KrakenClient(ILogger<KrakenClient> logger, KrakenApi api) : 
       );
       if (HasError(response))
         return 0.0;
-      TickerInfo tickerInfo;
-      tickerInfo = response.Result![pair].Parse();
+
+      // Kraken answers with its own canonical pair name (XXBTZUSD) even when asked for an alias
+      // (XBTUSD), so the single entry is taken by value instead of indexed by the requested name.
+      // Resolving alias and canonical names properly is P2-05.
+      if (response.Result!.Count != 1)
+      {
+        logger.LogError(
+          "Ticker for {Pair} returned {Count} entries (keys: {Keys}); no price to use.",
+          pair,
+          response.Result!.Count,
+          string.Join(", ", response.Result!.Keys)
+        );
+        return 0.0;
+      }
+      var tickerInfo = response.Result!.Values.Single().Parse();
 
       logger.LogInformation(
         "Current pair {Pair} price is: {CurrentPrice}",
@@ -62,7 +75,7 @@ public sealed class KrakenClient(ILogger<KrakenClient> logger, KrakenApi api) : 
     }
     catch (Exception e)
     {
-      logger.LogError("Could not query the current price: {Error}", e.Message);
+      logger.LogError("Could not query the current price of {Pair}: {Error}", pair, e.Message);
       return 0.0;
     }
   }

--- a/src/Kbot.Common/Api/KrakenClient.cs
+++ b/src/Kbot.Common/Api/KrakenClient.cs
@@ -49,7 +49,10 @@ public sealed class KrakenClient(ILogger<KrakenClient> logger, KrakenApi api) : 
         new Dictionary<string, string> { { "pair", pair } }
       );
       if (HasError(response))
+      {
+        logger.LogError("Ticker for {Pair} came back as an error response.", pair);
         return 0.0;
+      }
 
       // Kraken answers with its own canonical pair name (XXBTZUSD) even when asked for an alias
       // (XBTUSD), so the single entry is taken by value instead of indexed by the requested name.

--- a/src/Kbot.Common/Kbot.Common.csproj
+++ b/src/Kbot.Common/Kbot.Common.csproj
@@ -2,6 +2,7 @@
   <ItemGroup>
     <!-- Lets the test project reach the internal API surface and the HttpMessageHandler seam. -->
     <InternalsVisibleTo Include="Kbot.Common.Test" />
+    <InternalsVisibleTo Include="Kbot.DcaService.Test" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" />

--- a/src/Kbot.DcaService/DcaWorker.cs
+++ b/src/Kbot.DcaService/DcaWorker.cs
@@ -19,7 +19,12 @@ public class DcaWorker(
   IOptions<WaitOptions> waitOptions
 ) : BackgroundService
 {
-  private DcaState State { get; set; } = null!;
+  /// <summary>
+  /// Test seam: <see cref="InvestmentCycle"/> is exercised directly with a stubbed transport, which
+  /// needs the state seeded without going through <see cref="ExecuteAsync"/>. Extracting the
+  /// scheduling core into a pure component is P3-02.
+  /// </summary>
+  internal DcaState State { get; set; } = null!;
 
   // Options accessors for convenience
   private string CryptoPair => orderOptions.Value.CryptoPair;
@@ -80,7 +85,7 @@ public class DcaWorker(
     }
   }
 
-  private async Task<TimeSpan> InvestmentCycle(CancellationToken stoppingToken)
+  internal async Task<TimeSpan> InvestmentCycle(CancellationToken stoppingToken)
   {
     var balance = await krakenClient.CheckBalance();
     if (!balance.TryGetValue(FiatCode, out var fiatBalance))

--- a/src/Kbot.DcaService/DcaWorker.cs
+++ b/src/Kbot.DcaService/DcaWorker.cs
@@ -41,6 +41,12 @@ public class DcaWorker(
       balanceOptions.Value.DefaultTopupDayOfMonth
     );
     State = State with { NextTopUpTime = nextTopUpTime };
+    // A freshly loaded state carries TimeSpan.Zero, and the interval computation refuses to
+    // schedule on a non-positive top-up window, so seed it before the first cycle.
+    State = computeService.ComputeTimeUntilNextTopUp(
+      State,
+      balanceOptions.Value.DefaultTopupDayOfMonth
+    );
 
     while (!stoppingToken.IsCancellationRequested)
     {
@@ -61,9 +67,27 @@ public class DcaWorker(
   private async Task<TimeSpan> InvestmentCycle(CancellationToken stoppingToken)
   {
     var balance = await krakenClient.CheckBalance();
-    var balanceFiat = balance[FiatCode] - ReserveFiat;
+    if (!balance.TryGetValue(FiatCode, out var fiatBalance))
+    {
+      logger.LogError(
+        "Fiat asset {Fiat} is not in the Kraken balance (keys: {Keys}); skipping this cycle.",
+        FiatCode,
+        string.Join(", ", balance.Keys)
+      );
+      return waitOptions.Value.MaxWaitTime;
+    }
+    var balanceFiat = fiatBalance - ReserveFiat;
 
     var currentCryptoPrice = await krakenClient.GetCurrentCryptoPrice(CryptoPair);
+    if (currentCryptoPrice <= 0)
+    {
+      logger.LogError(
+        "Ticker for {CryptoPair} is unavailable (price {CurrentCryptoPrice}); skipping this cycle.",
+        CryptoPair,
+        currentCryptoPrice
+      );
+      return waitOptions.Value.MaxWaitTime;
+    }
     var askPrice = Math.Round(currentCryptoPrice * AskMultiplier, 1);
     var costForVolume =
       Math.Ceiling(askPrice * MinOrderVolume * InclusiveFeeMultiplier * 100) / 100;
@@ -84,7 +108,7 @@ public class DcaWorker(
       costForVolume,
       State.TimeUntilNextTopUp
     );
-    var nextOrderTime = State.LastInvestmentTime + investmentInterval;
+    var nextOrderTime = AddSaturating(State.LastInvestmentTime, investmentInterval);
 
     if (DateTime.UtcNow < nextOrderTime)
     {
@@ -108,6 +132,14 @@ public class DcaWorker(
     }
     return (nextOrderTime - DateTime.UtcNow) / 2;
   }
+
+  /// <summary>
+  /// Adds an interval to an instant without ever overflowing: the interval computation returns
+  /// <see cref="TimeSpan.MaxValue"/> when there is nothing to schedule, and plain
+  /// <see cref="DateTime"/> addition throws on that.
+  /// </summary>
+  private static DateTime AddSaturating(DateTime instant, TimeSpan interval) =>
+    interval >= DateTime.MaxValue - instant ? DateTime.MaxValue : instant + interval;
 
   private async Task<bool> SendOrder(double btcPrice)
   {

--- a/src/Kbot.DcaService/DcaWorker.cs
+++ b/src/Kbot.DcaService/DcaWorker.cs
@@ -34,6 +34,22 @@ public class DcaWorker(
   protected override async Task ExecuteAsync(CancellationToken stoppingToken)
   {
     logger.LogInformation("DCA Worker running at: {time}", DateTime.UtcNow);
+    // Stated explicitly because OrderType.Market is the enum default: an omitted OrderOptions__Type
+    // selects it, and a market order ignores the price this worker computes.
+    logger.LogInformation(
+      "Effective order type is {OrderType} for {CryptoPair}, volume {MinOrderVolume} at {AskMultiplier}x ask.",
+      orderOptions.Value.Type,
+      CryptoPair,
+      MinOrderVolume,
+      AskMultiplier
+    );
+    if (orderOptions.Value.Type == OrderType.Market)
+    {
+      logger.LogWarning(
+        "Order type is {OrderType}: orders execute at whatever the book offers, not at the computed price.",
+        OrderType.Market
+      );
+    }
 
     State = DcaStateHandler.Load();
     var nextTopUpTime = computeService.ComputeNextTopUpTime(

--- a/src/Kbot.DcaService/Kbot.DcaService.csproj
+++ b/src/Kbot.DcaService/Kbot.DcaService.csproj
@@ -3,6 +3,10 @@
     <UserSecretsId>b9200fc6-f2d1-4989-88b9-98debec7fd03</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <!-- Lets the test project drive one investment cycle against a stubbed transport. -->
+    <InternalsVisibleTo Include="Kbot.DcaService.Test" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Kbot.Common\Kbot.Common.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Kbot.DcaService/Options/OrderOptions.cs
+++ b/src/Kbot.DcaService/Options/OrderOptions.cs
@@ -20,6 +20,12 @@ public class OrderOptionsValidator : IValidateOptions<OrderOptions>
   {
     List<string> vor = [];
 
+    if (!Enum.IsDefined(options.Type))
+    {
+      vor.Add(
+        $"Type must be one of {string.Join(", ", Enum.GetNames<OrderType>())} (was {(int)options.Type})"
+      );
+    }
     if (options.Fee < 0)
     {
       vor.Add("Fee must be greater than or equal to 0");

--- a/src/Kbot.DcaService/Utility/TimeComputeService.cs
+++ b/src/Kbot.DcaService/Utility/TimeComputeService.cs
@@ -61,7 +61,33 @@ public class TimeComputeService(ILogger<TimeComputeService> logger, HolidayServi
     TimeSpan timeUntilNextTopUp
   )
   {
+    // Every degenerate input is answered with a finite, non-zero interval: dividing by a zero cost
+    // yields Infinity, and TimeSpan.Zero / Infinity is TimeSpan.Zero, which schedules an order
+    // immediately and then once per MinWaitTime.
+    if (timeUntilNextTopUp <= TimeSpan.Zero)
+    {
+      logger.LogWarning(
+        "No top-up window to spread investments over ({TimeUntilNextTopUp}); nothing to schedule.",
+        timeUntilNextTopUp
+      );
+      return TimeSpan.MaxValue;
+    }
+    if (balanceFiat <= 0 || costForVolume <= 0)
+    {
+      logger.LogWarning(
+        "Cannot compute an investment interval from balance {BalanceFiat} and cost {CostForVolume}; "
+          + "spreading over the whole top-up window instead.",
+        balanceFiat,
+        costForVolume
+      );
+      return timeUntilNextTopUp;
+    }
+
     var maxNrOfInvestmentsUntilNextTopUp = balanceFiat / costForVolume;
+    if (maxNrOfInvestmentsUntilNextTopUp < 1)
+    {
+      return timeUntilNextTopUp;
+    }
     var currentInvertval = timeUntilNextTopUp / maxNrOfInvestmentsUntilNextTopUp;
     return currentInvertval;
   }

--- a/src/Kbot.DcaService/Utility/TimeComputeService.cs
+++ b/src/Kbot.DcaService/Utility/TimeComputeService.cs
@@ -72,7 +72,12 @@ public class TimeComputeService(ILogger<TimeComputeService> logger, HolidayServi
       );
       return TimeSpan.MaxValue;
     }
-    if (balanceFiat <= 0 || costForVolume <= 0)
+    if (
+      balanceFiat <= 0
+      || costForVolume <= 0
+      || !double.IsFinite(balanceFiat)
+      || !double.IsFinite(costForVolume)
+    )
     {
       logger.LogWarning(
         "Cannot compute an investment interval from balance {BalanceFiat} and cost {CostForVolume}; "
@@ -89,6 +94,8 @@ public class TimeComputeService(ILogger<TimeComputeService> logger, HolidayServi
       return timeUntilNextTopUp;
     }
     var currentInvertval = timeUntilNextTopUp / maxNrOfInvestmentsUntilNextTopUp;
-    return currentInvertval;
+    // A count large enough to round the interval down to zero would order at MinWaitTime forever;
+    // the whole window is the safe answer for an input that degenerate.
+    return currentInvertval <= TimeSpan.Zero ? timeUntilNextTopUp : currentInvertval;
   }
 }

--- a/test/Kbot.Common.Test/KrakenApiRequestShapeTest.cs
+++ b/test/Kbot.Common.Test/KrakenApiRequestShapeTest.cs
@@ -46,6 +46,32 @@ public class KrakenApiRequestShapeTest
     }
   );
 
+  /// <summary>
+  /// What Kraken actually answers for the alias XBTUSD: the result is keyed by the canonical pair
+  /// name, which the client used to index by the requested name (C-2).
+  /// </summary>
+  private static readonly string CanonicalTickerResponse = JsonSerializer.Serialize(
+    new
+    {
+      error = Array.Empty<string>(),
+      result = new Dictionary<string, object>
+      {
+        ["XXBTZUSD"] = new
+        {
+          a = new[] { "50123.40000", "1", "1.000" },
+          b = new[] { "50100.10000", "2", "2.000" },
+          c = new[] { "50110.00000", "0.00100000" },
+          v = new[] { "10.00000000", "20.00000000" },
+          p = new[] { "50000.00000", "50050.00000" },
+          t = new[] { 100, 200 },
+          l = new[] { "49000.00000", "48000.00000" },
+          h = new[] { "51000.00000", "52000.00000" },
+          o = "50000.00000",
+        },
+      },
+    }
+  );
+
   private static readonly string AddOrderResponse = JsonSerializer.Serialize(
     new
     {
@@ -153,6 +179,43 @@ public class KrakenApiRequestShapeTest
     // Only that a price came back, not its value: the parse still runs under the current culture,
     // and pinning it to invariant culture is P2-02.
     Assert.AreNotEqual(0.0, price, "The ask price should have been parsed off the response.");
+  }
+
+  [TestMethod]
+  public async Task GetCurrentCryptoPrice_ParsesAResultKeyedByTheCanonicalPairName()
+  {
+    var handler = new RecordingHandler(CanonicalTickerResponse);
+    var api = new KrakenApi(
+      NullLogger<KrakenApi>.Instance,
+      MsOptions.Create(new Secrets()),
+      handler
+    );
+    using var client = new KrakenClient(NullLogger<KrakenClient>.Instance, api);
+
+    var price = await client.GetCurrentCryptoPrice("XBTUSD");
+
+    Assert.AreEqual("pair=XBTUSD", handler.Request!.RequestUri!.Query.TrimStart('?'));
+    Assert.AreNotEqual(
+      0.0,
+      price,
+      "A result keyed XXBTZUSD for a requested XBTUSD must still yield a price."
+    );
+  }
+
+  [TestMethod]
+  public async Task GetCurrentCryptoPrice_ReportsNoPriceWhenTheResultIsEmpty()
+  {
+    var handler = new RecordingHandler("""{"error":[],"result":{}}""");
+    var api = new KrakenApi(
+      NullLogger<KrakenApi>.Instance,
+      MsOptions.Create(new Secrets()),
+      handler
+    );
+    using var client = new KrakenClient(NullLogger<KrakenClient>.Instance, api);
+
+    // Still the 0.0 sentinel — replacing it with a typed result is P2-01. What matters here is that
+    // an unusable response is reported, not thrown, and that the worker refuses to trade on it.
+    Assert.AreEqual(0.0, await client.GetCurrentCryptoPrice("XBTUSD"));
   }
 
   private static string ExpectedSignature(string urlPath, string jsonBody, long nonce)

--- a/test/Kbot.DcaService.Test/InvestmentCycleGuardTest.cs
+++ b/test/Kbot.DcaService.Test/InvestmentCycleGuardTest.cs
@@ -1,0 +1,267 @@
+using System.Text;
+using System.Text.Json;
+using Kbot.Common.Api;
+using Kbot.Common.Enums;
+using Kbot.Common.Helpers;
+using Kbot.Common.Options;
+using Kbot.DcaService.Models;
+using Kbot.DcaService.Options;
+using Kbot.DcaService.Utility;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using MsOptions = Microsoft.Extensions.Options.Options;
+
+namespace Kbot.DcaService.Test;
+
+/// <summary>
+/// One investment cycle against a stubbed transport, covering the two sentinel call sites the worker
+/// used to consume unchecked: an empty balance dictionary (C-3) and a price of 0.0 (C-2). No
+/// network, no credentials, no order.
+/// </summary>
+[TestClass]
+public class InvestmentCycleGuardTest
+{
+  private static readonly TimeSpan MaxWaitTime = TimeSpan.FromHours(1);
+
+  private const string BalanceOfThousandFrancs =
+    """{"error":[],"result":{"CHF":"1000","XXBT":"0"}}""";
+  private const string BalanceWithoutFrancs = """{"error":[],"result":{"ZUSD":"1000"}}""";
+  private const string EmptyBalance = """{"error":[],"result":{}}""";
+  private const string TickerError = """{"error":["EQuery:Unknown asset pair"]}""";
+  private const string AddOrderAccepted =
+    """{"error":[],"result":{"txid":["OAV6BB-Q2SHQ-XSCJPG"],"descr":{"order":"buy 0.00005 XBTCHF @ limit 50000.0"}}}""";
+
+  // Whole numbers only: parsing the wire values still runs under the ambient culture, and pinning
+  // that to invariant culture is P2-02.
+  private static readonly string Ticker = JsonSerializer.Serialize(
+    new
+    {
+      error = Array.Empty<string>(),
+      result = new Dictionary<string, object>
+      {
+        ["XBTCHF"] = new
+        {
+          a = new[] { "50000", "1", "1" },
+          b = new[] { "49990", "2", "2" },
+          c = new[] { "49995", "1" },
+          v = new[] { "10", "20" },
+          p = new[] { "50000", "50050" },
+          t = new[] { 100, 200 },
+          l = new[] { "49000", "48000" },
+          h = new[] { "51000", "52000" },
+          o = "50000",
+        },
+      },
+    }
+  );
+
+  [TestMethod]
+  public async Task InvestmentCycle_SkipsTheCycleWhenTheBalanceCallFailed()
+  {
+    var transport = new StubKrakenTransport { Balance = EmptyBalance, Ticker = Ticker };
+
+    var (worker, log) = NewWorker(transport);
+    var waitTime = await worker.InvestmentCycle(CancellationToken.None);
+
+    Assert.AreEqual(MaxWaitTime, waitTime, "A failed balance call must cost one skipped cycle.");
+    Assert.IsFalse(transport.SawAddOrder, "No order may be constructed from an unknown balance.");
+    Assert.IsTrue(
+      log.Errors.Any(m => m.Contains("not in the Kraken balance")),
+      $"Expected a logged error about the missing fiat asset, got: {string.Join(" | ", log.Errors)}"
+    );
+  }
+
+  [TestMethod]
+  public async Task InvestmentCycle_SkipsTheCycleWhenTheFiatCodeIsNotKrakensAssetName()
+  {
+    // CultureOptions.Fiat is CHF while the account is funded in ZUSD: indexing the dictionary threw
+    // KeyNotFoundException out of the worker and stopped the host.
+    var transport = new StubKrakenTransport { Balance = BalanceWithoutFrancs, Ticker = Ticker };
+
+    var (worker, log) = NewWorker(transport);
+    var waitTime = await worker.InvestmentCycle(CancellationToken.None);
+
+    Assert.AreEqual(MaxWaitTime, waitTime);
+    Assert.IsFalse(transport.SawAddOrder);
+    Assert.IsTrue(log.Errors.Any(m => m.Contains("ZUSD")), "The available keys should be logged.");
+  }
+
+  [TestMethod]
+  public async Task InvestmentCycle_SkipsTheCycleWhenTheTickerIsUnavailable()
+  {
+    var transport = new StubKrakenTransport
+    {
+      Balance = BalanceOfThousandFrancs,
+      Ticker = TickerError,
+    };
+
+    var (worker, log) = NewWorker(transport);
+    var waitTime = await worker.InvestmentCycle(CancellationToken.None);
+
+    Assert.AreEqual(MaxWaitTime, waitTime, "A price of 0 must not start an investment.");
+    Assert.IsFalse(transport.SawAddOrder, "No order may be constructed from a price of 0.");
+    Assert.IsTrue(
+      log.Errors.Any(m => m.Contains("is unavailable")),
+      $"Expected a logged error about the ticker, got: {string.Join(" | ", log.Errors)}"
+    );
+  }
+
+  [TestMethod]
+  public async Task InvestmentCycle_StillOrdersOnAHealthyResponse()
+  {
+    // The counter-test: the guards above skip the cycle because the data is bad, not because a
+    // stubbed cycle can never place an order.
+    var transport = new StubKrakenTransport
+    {
+      Balance = BalanceOfThousandFrancs,
+      Ticker = Ticker,
+      AddOrder = AddOrderAccepted,
+    };
+
+    var (worker, _) = NewWorker(transport);
+    await worker.InvestmentCycle(CancellationToken.None);
+
+    Assert.IsTrue(transport.SawAddOrder, "A healthy cycle should have sent an order.");
+  }
+
+  [TestMethod]
+  public async Task InvestmentCycle_DoesNotOrderWithoutATopUpWindow()
+  {
+    // TimeUntilNextTopUp is TimeSpan.Zero in a freshly written state file. The interval used to come
+    // out as TimeSpan.Zero here, which put the next order time in the past on every cycle.
+    var transport = new StubKrakenTransport
+    {
+      Balance = BalanceOfThousandFrancs,
+      Ticker = Ticker,
+      AddOrder = AddOrderAccepted,
+    };
+
+    var (worker, _) = NewWorker(transport);
+    worker.State = worker.State with { TimeUntilNextTopUp = TimeSpan.Zero };
+    var waitTime = await worker.InvestmentCycle(CancellationToken.None);
+
+    Assert.IsFalse(transport.SawAddOrder, "An unschedulable cycle must not place an order.");
+    Assert.IsGreaterThan(
+      MaxWaitTime,
+      waitTime,
+      "The wait must be long enough for the caller's clamp to make it MaxWaitTime."
+    );
+  }
+
+  private static (DcaWorker Worker, RecordingLogger Log) NewWorker(StubKrakenTransport transport)
+  {
+    var cultureOptions = MsOptions.Create(
+      new CultureOptions
+      {
+        CultureString = "de-CH",
+        CountyCode = "CH-ZH",
+        Fiat = "CHF",
+      }
+    );
+    var log = new RecordingLogger();
+    var api = new KrakenApi(
+      NullLogger<KrakenApi>.Instance,
+      MsOptions.Create(new Secrets { ApiKey = "test-api-key", ApiSecret = "dGVzdC1zZWNyZXQ=" }),
+      transport
+    );
+    var worker = new DcaWorker(
+      log,
+      new TimeComputeService(
+        NullLogger<TimeComputeService>.Instance,
+        new HolidayService(NullLogger<HolidayService>.Instance, cultureOptions)
+      ),
+      new KrakenClient(NullLogger<KrakenClient>.Instance, api),
+      MsOptions.Create(
+        new OrderOptions
+        {
+          Type = OrderType.Limit,
+          Fee = 0.4,
+          MinOrderVolume = 0.00005,
+          AskMultiplier = 1.0,
+          CryptoPair = "XBTCHF",
+        }
+      ),
+      MsOptions.Create(new BalanceOptions { DefaultTopupDayOfMonth = 26, ReserveFiat = 100 }),
+      cultureOptions,
+      MsOptions.Create(
+        new WaitOptions { MinWaitTime = TimeSpan.FromSeconds(10), MaxWaitTime = MaxWaitTime }
+      )
+    )
+    {
+      // What ExecuteAsync would have loaded: due for an order, with a top-up window to spread over.
+      State = new DcaState
+      {
+        LastInvestmentTime = DateTime.UtcNow.AddDays(-1),
+        NextTopUpTime = DateTime.UtcNow.AddDays(5),
+        TimeUntilNextTopUp = TimeSpan.FromDays(5),
+      },
+    };
+    return (worker, log);
+  }
+
+  /// <summary>
+  /// Answers Kraken's balance, ticker and AddOrder endpoints from canned content and remembers
+  /// whether an order was ever sent.
+  /// </summary>
+  private sealed class StubKrakenTransport : HttpMessageHandler
+  {
+    internal string Balance { get; init; } = EmptyBalance;
+    internal string Ticker { get; init; } = TickerError;
+    internal string AddOrder { get; init; } = AddOrderAccepted;
+    internal bool SawAddOrder { get; private set; }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+      HttpRequestMessage request,
+      CancellationToken cancellationToken
+    )
+    {
+      var path = request.RequestUri!.AbsolutePath;
+      var content = path switch
+      {
+        "/0/private/Balance" => Balance,
+        "/0/public/Ticker" => Ticker,
+        "/0/private/AddOrder" => Order(),
+        _ => throw new InvalidOperationException($"Unexpected request to {path}."),
+      };
+      return Task.FromResult(
+        new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+        {
+          Content = new StringContent(content, Encoding.UTF8, "application/json"),
+        }
+      );
+    }
+
+    private string Order()
+    {
+      SawAddOrder = true;
+      return AddOrder;
+    }
+  }
+
+  /// <summary>
+  /// Keeps the messages the worker logged, so a skipped cycle can be told from a silent one.
+  /// </summary>
+  private sealed class RecordingLogger : ILogger<DcaWorker>
+  {
+    internal List<string> Errors { get; } = [];
+
+    public IDisposable? BeginScope<TState>(TState state)
+      where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+      LogLevel logLevel,
+      EventId eventId,
+      TState state,
+      Exception? exception,
+      Func<TState, Exception?, string> formatter
+    )
+    {
+      if (logLevel >= LogLevel.Error)
+      {
+        Errors.Add(formatter(state, exception));
+      }
+    }
+  }
+}

--- a/test/Kbot.DcaService.Test/InvestmentIntervalTest.cs
+++ b/test/Kbot.DcaService.Test/InvestmentIntervalTest.cs
@@ -1,0 +1,92 @@
+using Kbot.Common.Helpers;
+using Kbot.Common.Options;
+using Kbot.DcaService.Utility;
+using Microsoft.Extensions.Logging.Abstractions;
+using MsOptions = Microsoft.Extensions.Options.Options;
+
+namespace Kbot.DcaService.Test;
+
+/// <summary>
+/// The divisor guard in <see cref="TimeComputeService.ComputeNextInvestmentInterval"/> (C-2). A
+/// zero cost used to make the interval TimeSpan.Zero, which schedules an order immediately and then
+/// once per MinWaitTime.
+/// </summary>
+[TestClass]
+public class InvestmentIntervalTest
+{
+  private static readonly TimeSpan Window = TimeSpan.FromHours(10);
+
+  private static TimeComputeService NewService() =>
+    new(
+      NullLogger<TimeComputeService>.Instance,
+      new HolidayService(
+        NullLogger<HolidayService>.Instance,
+        MsOptions.Create(
+          new CultureOptions
+          {
+            CultureString = "de-CH",
+            CountyCode = "CH-ZH",
+            Fiat = "CHF",
+          }
+        )
+      )
+    );
+
+  [TestMethod]
+  // {zero, negative, positive} balance × {zero, negative, positive} cost.
+  [DataRow(0.0, 0.0)]
+  [DataRow(0.0, -1.0)]
+  [DataRow(0.0, 2.5)]
+  [DataRow(-1.0, 0.0)]
+  [DataRow(-1.0, -1.0)]
+  [DataRow(-1.0, 2.5)]
+  [DataRow(900.0, 0.0)]
+  [DataRow(900.0, -1.0)]
+  [DataRow(900.0, 2.5)]
+  public void ComputeNextInvestmentInterval_IsAlwaysFiniteAndNonZero(
+    double balanceFiat,
+    double costForVolume
+  )
+  {
+    var interval = NewService().ComputeNextInvestmentInterval(balanceFiat, costForVolume, Window);
+
+    Assert.IsGreaterThan(
+      TimeSpan.Zero,
+      interval,
+      $"balance {balanceFiat} and cost {costForVolume} produced {interval}, which orders at once."
+    );
+    Assert.IsLessThanOrEqualTo(
+      Window,
+      interval,
+      "An interval must never outlast the top-up window it spreads investments over."
+    );
+  }
+
+  [TestMethod]
+  public void ComputeNextInvestmentInterval_SpreadsTheBudgetOverTheWindow()
+  {
+    var interval = NewService().ComputeNextInvestmentInterval(100.0, 10.0, Window);
+
+    Assert.AreEqual(Window / 10, interval, "10 affordable orders should be one per tenth window.");
+  }
+
+  [TestMethod]
+  public void ComputeNextInvestmentInterval_WaitsTheWholeWindowWhenNothingIsAffordable()
+  {
+    var interval = NewService().ComputeNextInvestmentInterval(5.0, 10.0, Window);
+
+    Assert.AreEqual(Window, interval, "A budget below one order cannot be spread out further.");
+  }
+
+  [TestMethod]
+  [DataRow(0)]
+  [DataRow(-1)]
+  public void ComputeNextInvestmentInterval_SchedulesNothingWithoutATopUpWindow(int windowHours)
+  {
+    var interval = NewService()
+      .ComputeNextInvestmentInterval(900.0, 2.5, TimeSpan.FromHours(windowHours));
+
+    // MaxValue keeps the caller's clamp in charge: it becomes MaxWaitTime, never an immediate order.
+    Assert.AreEqual(TimeSpan.MaxValue, interval);
+  }
+}

--- a/test/Kbot.DcaService.Test/InvestmentIntervalTest.cs
+++ b/test/Kbot.DcaService.Test/InvestmentIntervalTest.cs
@@ -43,6 +43,13 @@ public class InvestmentIntervalTest
   [DataRow(900.0, 0.0)]
   [DataRow(900.0, -1.0)]
   [DataRow(900.0, 2.5)]
+  // And the inputs no arithmetic survives: not-a-number, infinity, and a cost so small that the
+  // interval would round down to zero ticks.
+  [DataRow(double.NaN, 2.5)]
+  [DataRow(900.0, double.NaN)]
+  [DataRow(double.PositiveInfinity, 2.5)]
+  [DataRow(900.0, double.PositiveInfinity)]
+  [DataRow(double.MaxValue, double.Epsilon)]
   public void ComputeNextInvestmentInterval_IsAlwaysFiniteAndNonZero(
     double balanceFiat,
     double costForVolume


### PR DESCRIPTION
Implements [docs/plans/p1-02-c2-c3-guard-worker-sentinels.md](docs/plans/p1-02-c2-c3-guard-worker-sentinels.md).

Closes **C-2** (a failed ticker call returns `0.0` and the worker trades on it) and **C-3** (a failed balance call returns `[]` and the worker indexes it).

## What changed

- **`KrakenClient.GetCurrentCryptoPrice`** takes the single ticker entry by value instead of indexing by the requested pair name. Kraken echoes its canonical name (`XXBTZUSD`) for an alias (`XBTUSD`), which threw `KeyNotFoundException` into the `0.0` error path. An unexpected entry count is logged with the returned keys. The `0.0` sentinel stays — P2-01 replaces the protocol.
- **`DcaWorker.InvestmentCycle`** guards both results before any arithmetic and returns `MaxWaitTime`, so a failed call costs one skipped cycle instead of a crash (`balance[FiatCode]`) or an order priced off `0`.
- **`TimeComputeService.ComputeNextInvestmentInterval`** refuses to divide by a non-positive cost or balance, and returns `TimeSpan.MaxValue` for a non-positive top-up window. No caller can produce `Zero`, `Infinity` or `NaN` any more.
- **`OrderOptions`** rejects an out-of-range `Type`, and the worker logs the effective order type once at startup, warning when it is `Market` (the enum default, which an omitted `OrderOptions__Type` selects). The rest of the validator tightening is P1-07.

Two knock-on changes the plan's scope implies but does not spell out:

- `TimeSpan.MaxValue` would overflow `State.LastInvestmentTime + investmentInterval`, so that addition now saturates at `DateTime.MaxValue` and the caller's clamp turns it into `MaxWaitTime`.
- A freshly loaded state carries `TimeUntilNextTopUp = TimeSpan.Zero`, which the new non-positive-window guard would otherwise turn into "never invest". `ExecuteAsync` seeds `TimeUntilNextTopUp` before the first cycle.

## Verified

```
dotnet build Kbot.sln -warnaserror            # clean, 0 warnings
dotnet test Kbot.sln --filter "TestCategory!=LiveExchange&TestCategory!=LiveApi"
                                              # 35 passed, 0 failed
csharpier check .                             # clean, 73 files
```

Acceptance criteria, each covered by a test:

| Criterion | Test |
|---|---|
| Empty balance → error logged, `MaxWaitTime`, no order | `InvestmentCycle_SkipsTheCycleWhenTheBalanceCallFailed` |
| Fiat code absent from a funded balance | `InvestmentCycle_SkipsTheCycleWhenTheFiatCodeIsNotKrakensAssetName` |
| Price `0` → same | `InvestmentCycle_SkipsTheCycleWhenTheTickerIsUnavailable` |
| Guards do not simply disable ordering | `InvestmentCycle_StillOrdersOnAHealthyResponse` |
| No degenerate interval over `{0, −, +} × {0, −, +}` | `ComputeNextInvestmentInterval_IsAlwaysFiniteAndNonZero` (9 rows) |
| `XBTUSD` request, `XXBTZUSD`-keyed payload parses | `GetCurrentCryptoPrice_ParsesAResultKeyedByTheCanonicalPairName` |

All new tests are hermetic — a stubbed `HttpMessageHandler`, no credentials, no network.

## Docs

This PR also carries the status updates, so nothing has to be corrected on `review-and-fix` after
the merge: [the plan file](docs/plans/p1-02-c2-c3-guard-worker-sentinels.md) gains a Status row and a
Resolution section, and the status board, Wave 0 tables, finding→plan matrix and the C-2 / C-3
findings in `REVIEW.md` all read as resolved.

One correction rather than a tick: the Wave 0 notes assumed **P1-03** would reach `DcaWorker.cs` and
`TimeComputeService.cs` first. P1-02 got there instead, so the merge-order guidance and the P1-03,
P1-04 and P1-07 agent prompts now describe what is already in those files.

And the workflow itself is now written down, so the next plan does this without being asked:
[Closing out a plan](docs/plans/README.md#closing-out-a-plan) in the working protocol, a rule in each
of the nine §5 agent prompts, and a line in the definition of done saying the close-out docs are the
one thing a PR changes outside its plan's scope.

## Deliberately left out

- `KrakenResult<T>` / nullable signatures → **P2-01**
- Top-up day clamp and state-save ordering → **P1-03**
- `try`/`catch` + backoff around the loop → **P1-04**
- Canonical pair names from `AssetPairs` → **P2-05**
- *Available* rather than *total* balance → **P4-09** (M-2)
- Invariant-culture parsing → **P2-02**. The new stubs use whole-number wire values so they do not depend on the ambient culture.

`DcaWorker.State` and `InvestmentCycle` became `internal` (plus `InternalsVisibleTo` for the test projects) so one cycle can be driven without the host loop; the real seam extraction is P3-01/P3-02.

