### PR TITLE
fix: P1-08 remove the committed DB password and published Postgres port (H-11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ Then it will wait about 24 hours until the next mail should be sent.
 ### Installation
 Please have a look at the wiki [https://github.com/Zuricos/dotnet-kraken-dca-bot/wiki/Installation](https://github.com/Zuricos/dotnet-kraken-dca-bot/wiki/Installation)
 
+> **Set your own database password in both places before the first start.** `POSTGRES_PASSWORD` in
+> [docker/stack.env](docker/stack.env) ships as the placeholder `<CHANGE_ME>`, and the matching
+> `ConnectionStrings:Kraken` belongs in your mail-service docker secret file (see
+> [src/docker.mail.secrets-template.json](src/docker.mail.secrets-template.json)) — the two passwords
+> must be identical. `mail-service` refuses to start if the connection string is missing. If you
+> already deployed an earlier version, that database is still using the password published in this
+> repository: change it and recreate the stack.
+
 ## Miscellaneous
 ### Tipps
 Create a Subaccount for the DCA and create the api keys for it. If you want to trade without the bot intercept your trading wallet and use the money which is designed for trading.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -435,6 +435,13 @@ There is no `WaitOptions` section in `appsettings.json`, so an operator who forg
 
 ### H-11 · Committed database password plus Postgres published on all host interfaces
 
+> ✅ **Resolved** by [P1-08](docs/plans/p1-08-h11-database-credentials-exposure.md), merged as PR #44.
+> The `ports` block is gone (a loopback-only mapping is left commented out), `stack.env` carries a
+> `<CHANGE_ME>` placeholder for `POSTGRES_PASSWORD` and no connection string at all, and
+> `appsettings.json` no longer ships one — the mail service now fails fast with a message naming
+> `ConnectionStrings:Kraken`. Operators who already deployed the default must rotate it; removing it
+> from the repository does not change an existing database.
+
 **Files:** [stack.env:19,23](docker/stack.env#L19) · [example-compose.yaml:31-32](docker/example-compose.yaml#L31-L32) · [appsettings.json:3](src/Kbot.MailService/appsettings.json#L3)
 
 `POSTGRES_PASSWORD="NotYourK3yNotYourCoin$"` is committed in `stack.env` **and baked into `appsettings.json`**, therefore into the published image. The compose file publishes `ports: - "5432:5432"`, binding Postgres to all host interfaces.

--- a/docker/example-compose.yaml
+++ b/docker/example-compose.yaml
@@ -28,8 +28,11 @@ services:
     container_name: kraken-database
     env_file:
       - stack.env
-    ports:
-      - "5432:5432"
+    # No host port is published: mail-service reaches the database by service name over the
+    # compose network. Publishing 5432 would expose the database to every host on your LAN.
+    # For local debugging only, bind it to loopback and nothing else:
+    # ports:
+    #   - "127.0.0.1:5432:5432"
     volumes:
       - pg_data:/var/lib/postgresql/data
     restart: always

--- a/docker/stack.env
+++ b/docker/stack.env
@@ -16,8 +16,26 @@ MailOptions__CryptoPair="XBTCHF"
 MailOptions__Crypto="BTC"
 MailOptions__Fiat="CHF"
 MailOptions__HistoryStartDate="2024-12-01"
-ConnectionStrings__Kraken="Host=kraken-database;Database=Kbot;Username=postgres;Password=NotYourK3yNotYourCoin$"
+
+# ---------------------------------------------------------------------------
+# THIS FILE IS COMMITTED TO THE REPOSITORY - never put a real secret in it.
+# Real secrets belong in the docker secret files that compose mounts as
+# /run/secrets/dca-secrets and /run/secrets/mail-secrets; see
+# ../src/docker.mail.secrets-template.json and ../src/docker.dca.secrets-template.json.
+# ---------------------------------------------------------------------------
+
+# The database connection string is a secret, so it is NOT set here any more.
+# Put it in the mail-service secret file instead:
+#   "ConnectionStrings": {
+#     "Kraken": "Host=kraken-database;Database=Kbot;Username=postgres;Password=<CHANGE_ME>"
+#   }
+# mail-service refuses to start when ConnectionStrings:Kraken is missing.
+# The password inside it and POSTGRES_PASSWORD below MUST be the same value.
 
 POSTGRES_DB="Kbot"
 POSTGRES_USER="postgres"
-POSTGRES_PASSWORD="NotYourK3yNotYourCoin$"
+# The postgres image only accepts its password as an environment variable, so this one
+# placeholder has to stay in this committed file. Replace <CHANGE_ME> with your own
+# password before the first start, and keep it identical to the password in the
+# connection string in the mail-service secret file above.
+POSTGRES_PASSWORD="<CHANGE_ME>"

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -14,8 +14,8 @@ then follow §8 to produce the next handoff.
 |---|---|
 | Repo | `dotnet-kraken-dca-bot` — a .NET 10 Kraken DCA bot (6 projects: `Kbot.Common`, `Kbot.DcaService`, `Kbot.MailService` + 3 test projects) |
 | What exists | A full code review ([REVIEW.md](../REVIEW.md)), a phased roadmap ([ROADMAP.md](ROADMAP.md)) and 37 branch-sized implementation plans ([plans/](plans/)) |
-| What has been fixed | **4 of 64 findings.** C-1 (P1-01), C-2 / C-3 (P1-02) and C-4 (P1-03) are merged. The rest are open. |
-| Branch state | `main` = upstream, untouched. `review-and-fix` = `main` + the review + these docs, and **the integration branch all work merges into**. P1-01 (`58c2262`) and P1-02 (#43) have landed there; everything else is still open. |
+| What has been fixed | **5 of 64 findings.** C-1 (P1-01), C-2 / C-3 (P1-02), C-4 (P1-03) and H-11 (P1-08) are merged. The rest are open. |
+| Branch state | `main` = upstream, untouched. `review-and-fix` = `main` + the review + these docs, and **the integration branch all work merges into**. P1-01 (`58c2262`), P1-02 (#43) and P1-08 (#44) have landed there; everything else is still open. |
 
 **The one thing to know:** the review's verdict is *"not safe to run unattended with real money until
 C-1 … C-5 are fixed."* Those five findings are owned by plans **P1-01, P1-02, P1-03, P1-04**. They are
@@ -70,7 +70,7 @@ If you ever see a plan or an older doc say "base on `main`", it is stale — thi
 | 4 | [P1-04](plans/p1-04-c5-worker-loop-resilience.md) | `fix/p1-c5-worker-loop-resilience` | **C-5** | S |
 | 5 | [P1-06](plans/p1-06-h4-dockerignore-and-secret-copy.md) | `fix/p1-h4-dockerignore-and-secret-copy` | H-4 | S |
 | 6 | [P1-07](plans/p1-07-h10-tighten-options-validators.md) | `fix/p1-h10-tighten-options-validators` | H-10 | S |
-| 7 | [P1-08](plans/p1-08-h11-database-credentials-exposure.md) | `fix/p1-h11-database-credentials-exposure` | H-11 | S |
+| ~~7~~ | ~~[P1-08](plans/p1-08-h11-database-credentials-exposure.md)~~ ✅ merged | `fix/p1-h11-database-credentials-exposure` | H-11 | S |
 | 8 | [P1-09](plans/p1-09-m16-redact-secrets-in-logs.md) | `fix/p1-m16-redact-secrets-in-logs` | M-16 | XS |
 | 9 | [P2-02](plans/p2-02-h1-invariant-culture.md) | `fix/p2-h1-invariant-culture` | H-1 | M |
 
@@ -308,7 +308,7 @@ Rules:
 </details>
 
 <details>
-<summary><b>P1-08 · Remove the committed DB password and published port (H-11)</b></summary>
+<summary><b>P1-08 · Remove the committed DB password and published port (H-11) — ✅ merged as #44, nothing to do</b></summary>
 
 ```
 Work in the repo dotnet-kraken-dca-bot.
@@ -450,7 +450,7 @@ Every PR updates its own row, on its own branch, before it is opened — see
 | P1-04 | `fix/p1-c5-worker-loop-resilience` | — | | |
 | P1-06 | `fix/p1-h4-dockerignore-and-secret-copy` | — | | |
 | P1-07 | `fix/p1-h10-tighten-options-validators` | — | | |
-| P1-08 | `fix/p1-h11-database-credentials-exposure` | — | | |
+| P1-08 | `fix/p1-h11-database-credentials-exposure` | ✅ resolved | #44 | via #44 |
 | P1-09 | `fix/p1-m16-redact-secrets-in-logs` | — | | |
 | P2-02 | `fix/p2-h1-invariant-culture` | — | | |
 
@@ -469,7 +469,7 @@ Each merge unlocks specific plans. From [ROADMAP.md](ROADMAP.md) §4:
 | ✅ P1-03 *(merged)* | **P1-10** (`test/p1-h12-deterministic-timecompute-tests`) — **now ready**; the clamp it has to assert is in |
 | ✅ P1-02 *(merged)* **and** P1-04 | **P2-01** (`refactor/p2-i1-kraken-result-protocol`) — the highest-value change in the review; now waiting on P1-04 alone |
 | ✅ P1-03 *(merged)* **and** P1-07 | **P2-08** (`refactor/p2-i5-shared-trading-options`) — now waiting on P1-07 alone |
-| P1-08 | **P4-06** (`fix/p4-m17-m21-startup-and-healthchecks`) |
+| ✅ P1-08 *(merged)* | **P4-06** (`fix/p4-m17-m21-startup-and-healthchecks`) — **now ready**; the compose file no longer carries the port mapping or the password |
 | P1-05 | **P2-09** (`ci/p2-workflow-hardening`) |
 | P2-02 | **P2-03** (`refactor/p2-h2-decimal-money`) |
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -150,7 +150,7 @@ merge order matters (see the note below) but their *development* does not.
 | P1-04 | `fix/p1-c5-worker-loop-resilience` | C-5 |
 | P1-06 | `fix/p1-h4-dockerignore-and-secret-copy` | H-4 |
 | P1-07 | `fix/p1-h10-tighten-options-validators` | H-10 |
-| P1-08 | `fix/p1-h11-database-credentials-exposure` | H-11 |
+| ~~P1-08~~ ✅ merged | `fix/p1-h11-database-credentials-exposure` | H-11 |
 | P1-09 | `fix/p1-m16-redact-secrets-in-logs` | M-16 |
 | P2-02 | `fix/p2-h1-invariant-culture` | H-1 |
 
@@ -174,10 +174,10 @@ merge order matters (see the note below) but their *development* does not.
 | P4-02 | — (soft: P3-01) | `fix/p4-h7-holiday-cache-resilience` |
 | P4-03 | — (soft: P3-01) | `refactor/p4-h8-httpclient-lifetimes-resilience` |
 | P4-05 | — | `fix/p4-i4-nonce-monotonicity` |
-| P4-06 | P1-08 | `fix/p4-m17-m21-startup-and-healthchecks` |
+| P4-06 | ✅ P1-08 *(merged — ready now)* | `fix/p4-m17-m21-startup-and-healthchecks` |
 | P4-07 | — (soft: P3-01) | `refactor/p4-m22-mail-transport-mailkit` |
 | P4-10 | — (soft: P2-02, P2-03) | `fix/p4-parsing-and-config-robustness` |
-| P5-01 | — (best after P1-08, P2-08, P4-09) | `docs/p5-readme-accuracy` |
+| P5-01 | — (best after ✅ P1-08, P2-08, P4-09) | `docs/p5-readme-accuracy` |
 
 > **Phase 4 is unusually independent.** P4-01/02/03/05/06/07 need nothing from Phase 2 or 3 — they are
 > only *smaller* after P3-01. If you have spare parallel capacity while Phase 2 is in flight, this is
@@ -236,7 +236,7 @@ Every finding in REVIEW.md, with its owning plan. Use this to check nothing was 
 | H-8 | P4-03 | M-13 | P4-08 |
 | H-9 | P2-06 | M-14 | P4-10 |
 | H-10 | P1-07 | M-15 | P4-10 |
-| H-11 | P1-08 | M-16 | P1-09 |
+| H-11 ✅ | P1-08 *(merged)* | M-16 | P1-09 |
 | H-12 | P1-10 | M-17 | P4-06 |
 | I-1 | P2-01 | M-18 | P2-09 |
 | I-2 | P2-04 | M-19 | P2-09 |
@@ -273,8 +273,8 @@ order up front.
 | `src/Kbot.MailService/Utility/OrderService.cs` | P2-01, P2-04, P2-06, P4-08 | P2-01 → P2-06 → P2-04 → P4-08 |
 | `src/Kbot.MailService/Migrations/**` | P2-03, P2-04 | P2-03 → P2-04 (**never in parallel** — two pending migrations conflict) |
 | `.github/workflows/**` | P1-05, P2-09, P5-02 | P1-05 → P2-09 → P5-02 |
-| `docker/example-compose.yaml` | P1-08, P4-06, P5-02 | P1-08 → P4-06 → P5-02 |
-| `docker/stack.env` | P1-08, P2-08, P4-10 | P1-08 → P2-08 → P4-10 |
+| `docker/example-compose.yaml` | P1-08 ✅, P4-06, P5-02 | P1-08 *(merged)* → P4-06 → P5-02 |
+| `docker/stack.env` | P1-08 ✅, P2-08, P4-10 | P1-08 *(merged)* → P2-08 → P4-10 |
 | `README.md` | P4-05, P5-01, P5-02, P5-03 | P5-01 → P5-02 → P5-03 (P4-05 adds one section; merge whenever) |
 | Both `ServiceCollectionExtension.cs` | P1-07, P2-08, P3-01, P4-03, P5-04 | P1-07 → P2-08 → P3-01 → P4-03 → P5-04 |
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -114,7 +114,7 @@ the Resolution section what you left out and which plan owns it.
 | P1-05 | H-3 | CI: build, test, format gate | `ci/p1-h3-build-test-lint-pipeline` |
 | P1-06 | H-4 | Fix the inert `.dockerignore` and the `secrets.json` copy | `fix/p1-h4-dockerignore-and-secret-copy` |
 | P1-07 | H-10 | Tighten the options validators | `fix/p1-h10-tighten-options-validators` |
-| P1-08 | H-11 | Remove the committed DB password and published port | `fix/p1-h11-database-credentials-exposure` |
+| P1-08 ✅ | H-11 | Remove the committed DB password and published port *(resolved — #44)* | `fix/p1-h11-database-credentials-exposure` |
 | P1-09 | M-16 | Stop logging the API secret | `fix/p1-m16-redact-secrets-in-logs` |
 | P1-10 | H-12 | Deterministic `TimeComputeService` tests | `test/p1-h12-deterministic-timecompute-tests` |
 | **Phase 2 — contract & numeric correctness** ||||

--- a/docs/plans/p1-08-h11-database-credentials-exposure.md
+++ b/docs/plans/p1-08-h11-database-credentials-exposure.md
@@ -2,12 +2,13 @@
 
 |  |  |
 |---|---|
+| **Status** | ✅ **Resolved** — merged into `review-and-fix` via PR #44 |
 | **Findings** | H-11 |
 | **Phase** | 1 — Stop the bleeding |
 | **Branch** | `fix/p1-h11-database-credentials-exposure` |
 | **Effort** | S (~1 h) |
 | **Depends on** | — (start immediately) |
-| **Blocks** | — (P4-06 also edits `example-compose.yaml`; merge this first) |
+| **Blocks** | P4-06 (also edits `example-compose.yaml`) — **unblocked by this merge** |
 | **Conflict surface** | `docker/stack.env`, `docker/example-compose.yaml` (also P4-06), `src/Kbot.MailService/appsettings.json` |
 
 ## Problem
@@ -71,3 +72,72 @@ docker compose -f docker/example-compose.yaml config >/dev/null && echo "compose
 dotnet build Kbot.sln -warnaserror
 dotnet test Kbot.sln --filter "TestCategory!=LiveExchange&TestCategory!=LiveApi"
 ```
+
+---
+
+## Resolution
+
+Merged into `review-and-fix` from `fix/p1-h11-database-credentials-exposure` as PR #44. **H-11 is
+closed**: no committed file carries a usable database password any more, the database is no longer
+reachable from the host network, and a mail service without a configured connection string refuses to
+start instead of falling back to a password published on GitHub.
+
+What landed:
+
+- [docker/example-compose.yaml](../../docker/example-compose.yaml) — the `ports: - "5432:5432"` block
+  is gone from `kraken-database`. `mail-service` reaches the database by service name over the compose
+  network, so no host port is needed; a loopback-only `# - "127.0.0.1:5432:5432"` stays commented out
+  as a local debugging escape hatch, with a one-line warning about what publishing it costs.
+- [docker/stack.env](../../docker/stack.env) — `ConnectionStrings__Kraken` is removed from this
+  committed file and documented in the mail-service secret template instead. `POSTGRES_PASSWORD`
+  stays, because the postgres image only accepts its password as an environment variable, but as the
+  placeholder `<CHANGE_ME>`; a comment block says the file is committed, that real secrets belong in
+  the docker secret files, and that the two passwords must match.
+- [src/Kbot.MailService/appsettings.json](../../src/Kbot.MailService/appsettings.json) — the whole
+  `ConnectionStrings` block is deleted, so the credential is no longer baked into the published image.
+- [src/Kbot.MailService/Utility/ServiceCollectionExtension.cs](../../src/Kbot.MailService/Utility/ServiceCollectionExtension.cs)
+  — an explicit null/empty guard before `AddDbContextFactory` throws `InvalidOperationException`
+  naming `ConnectionStrings:Kraken` and both places it can be supplied, rather than letting Npgsql
+  fail later with an opaque error.
+- [src/docker.mail.secrets-template.json](../../src/docker.mail.secrets-template.json) — documents
+  `ConnectionStrings:Kraken` as the recommended home for the credential, alongside the Kraken and
+  SMTP secrets that were already handled that way.
+- [README.md](../../README.md) — a three-line note under Installation: set your own password in both
+  places before the first start, and rotate it if you already deployed an earlier version.
+
+Two things the scope implied but did not spell out:
+
+- `ConnectionStrings__Kraken` had to be *removed* from `stack.env` rather than left as a placeholder.
+  `AddEnvironmentVariables()` is registered after the secret file, so an env var would have silently
+  overridden the docker secret the plan asks operators to use.
+- [src/Kbot.MailService/secrets-template.json](../../src/Kbot.MailService/secrets-template.json) got
+  the same entry. With no fallback in `appsettings.json`, local development needs the connection
+  string in user secrets, and the template is where a developer looks for the shape.
+
+Tests: [ConnectionStringGuardTest.cs](../../test/Kbot.MailService.Test/ConnectionStringGuardTest.cs) —
+a missing and a blank `ConnectionStrings:Kraken` each fail fast with a message naming the setting, and
+a configured one composes the service graph normally.
+
+Verified: `dotnet build Kbot.sln -warnaserror` clean, 49 tests pass under the default filter
+(rebased onto P1-03),
+`csharpier check .` clean, `docker compose -f docker/example-compose.yaml config` valid with no
+published port on any service.
+
+`git grep -n 'NotYourK3y'` is clean across every shipped file
+(`-- ':!REVIEW.md' ':!docs/'`). The literal survives only in the REVIEW.md finding text — the
+historical record the close-out protocol says to leave alone — and in this plan's own Problem and
+Verification sections, which quote it to describe the bug.
+
+Deliberately not done:
+
+- Rotating a password an operator already deployed — that is an operator action, called out in the PR
+  body and in the README note. The breaking-change CHANGELOG entry → **P5-02**.
+- Rewriting git history to purge the password. Recording the decision: it is a documented default
+  rather than any single deployment's live credential, every reachable copy is now a placeholder or a
+  historical reference, and a force-pushed rewrite of a public repository costs every fork more than
+  it buys. Rotation is the mitigation.
+- `depends_on` and a healthcheck for `kraken-database`, and pinning `postgres:latest` → **P4-06**
+  (M-17, M-21). Only the `ports` block was touched, so that plan's diff on the same file stays small.
+- The larger README rewrite → **P5-01**.
+
+Follow-ups unblocked: **P4-06** — its only hard prerequisite was this plan.

--- a/docs/plans/p2-08-i5-shared-trading-options.md
+++ b/docs/plans/p2-08-i5-shared-trading-options.md
@@ -8,7 +8,7 @@
 | **Effort** | M (~5 h) |
 | **Depends on** | ✅ **P1-03** — merged (#45); **P1-07** (validator tightening) is the one still open |
 | **Blocks** | — (but **P2-05** consumes it; coordinate whichever lands second) |
-| **Conflict surface** | `src/Kbot.Common/Options/**`, `src/Kbot.DcaService/Options/**`, `src/Kbot.MailService/Options/MailOptions.cs`, both `ServiceCollectionExtension.cs`, `docker/stack.env` (also P1-08, P4-10) |
+| **Conflict surface** | `src/Kbot.Common/Options/**`, `src/Kbot.DcaService/Options/**`, `src/Kbot.MailService/Options/MailOptions.cs`, both `ServiceCollectionExtension.cs`, `docker/stack.env` (also P4-10; P1-08 is merged — it removed `ConnectionStrings__Kraken` from that file and left `POSTGRES_PASSWORD` as a placeholder) |
 
 ## Problem
 

--- a/docs/plans/p4-06-m17-m21-startup-and-healthchecks.md
+++ b/docs/plans/p4-06-m17-m21-startup-and-healthchecks.md
@@ -6,9 +6,9 @@
 | **Phase** | 4 — Operational hardening |
 | **Branch** | `fix/p4-m17-m21-startup-and-healthchecks` |
 | **Effort** | M (~5 h) |
-| **Depends on** | **P1-08** (same compose file — merge that first), soft **P1-04** |
+| **Depends on** | ✅ **P1-08** — merged as PR #44, so this is **ready now**; soft **P1-04** |
 | **Blocks** | `FUTURE_FEATURES.md` **F-1** (self-monitoring builds directly on this) |
-| **Conflict surface** | `docker/example-compose.yaml` (also P1-08), both Dockerfiles, `src/Kbot.MailService/Database/MigrationService.cs`, `src/Kbot.MailService/Program.cs` |
+| **Conflict surface** | `docker/example-compose.yaml` (P1-08 is merged: the `ports` block is already gone and `POSTGRES_PASSWORD` is already a placeholder — do not re-add either), both Dockerfiles, `src/Kbot.MailService/Database/MigrationService.cs`, `src/Kbot.MailService/Program.cs` |
 
 ## Problem
 
@@ -61,7 +61,7 @@ and stops trading indefinitely — the project's core failure mode is *silence*.
 
 ### Out of scope
 - Prometheus metrics and the dead-man's-switch alert mail → `FUTURE_FEATURES.md` **F-1**.
-- Removing the published Postgres port and the committed password → **P1-08**.
+- Removing the published Postgres port and the committed password → **P1-08** *(done — merged as #44)*.
 - Cancellation/shutdown behaviour → **P4-04**.
 
 ## Acceptance criteria

--- a/docs/plans/p4-10-parsing-and-config-robustness.md
+++ b/docs/plans/p4-10-parsing-and-config-robustness.md
@@ -8,7 +8,7 @@
 | **Effort** | S–M (~5 h) |
 | **Depends on** | Soft: **P2-02** (culture) and **P2-03** (types) touch the same DTOs — merge those first |
 | **Blocks** | — |
-| **Conflict surface** | `src/Kbot.Common/Conversion/OrderParser.cs`, `src/Kbot.Common/Dtos/**`, `src/Kbot.Common/Api/KrakenApi.cs` (also P4-05), `src/Kbot.Common/Options/CultureOptions.cs`, `docker/stack.env` (also P1-08, P2-08) |
+| **Conflict surface** | `src/Kbot.Common/Conversion/OrderParser.cs`, `src/Kbot.Common/Dtos/**`, `src/Kbot.Common/Api/KrakenApi.cs` (also P4-05), `src/Kbot.Common/Options/CultureOptions.cs`, `docker/stack.env` (also P2-08; P1-08 is merged — its comment block and the `POSTGRES_PASSWORD` placeholder are already there) |
 
 > Six independent robustness defects. One commit each.
 

--- a/docs/plans/p5-01-readme-accuracy.md
+++ b/docs/plans/p5-01-readme-accuracy.md
@@ -26,7 +26,9 @@
 
 ### In scope
 1. Replace every SQLite reference with PostgreSQL, including the storage-provisioning instructions,
-   and document the `ConnectionStrings__Kraken` requirement (post-**P1-08**: no default password).
+   and document the `ConnectionStrings__Kraken` requirement (**P1-08** is merged: there is no default
+   password, and the mail service fails fast without the setting — the README already carries a
+   three-line note that this section should absorb).
 2. State the license correctly: **AGPL-3.0**, with a one-line summary of the network-copyleft
    obligation and a link to `LICENSE`.
 3. Document **UTC semantics** everywhere a time appears: `MailOptions__HourOfDay`,

--- a/src/Kbot.MailService/Utility/ServiceCollectionExtension.cs
+++ b/src/Kbot.MailService/Utility/ServiceCollectionExtension.cs
@@ -18,9 +18,20 @@ public static class ServiceCollectionExtension
   {
     services.SetupOptions(configuration);
 
+    var connectionString = configuration.GetConnectionString("Kraken");
+    if (string.IsNullOrWhiteSpace(connectionString))
+    {
+      throw new InvalidOperationException(
+        "The database connection string 'ConnectionStrings:Kraken' is not configured. "
+          + "Set it in the mail-service docker secret file (mounted at /run/secrets/mail-secrets, "
+          + "see src/docker.mail.secrets-template.json) or via the ConnectionStrings__Kraken "
+          + "environment variable. It is deliberately not shipped with the image."
+      );
+    }
+
     services.AddDbContextFactory<KrakenDbContext>(options =>
     {
-      options.UseNpgsql(connectionString: configuration.GetConnectionString("Kraken"));
+      options.UseNpgsql(connectionString: connectionString);
     });
 
     services.AddTransient<OrderService>();

--- a/src/Kbot.MailService/appsettings.json
+++ b/src/Kbot.MailService/appsettings.json
@@ -1,7 +1,4 @@
 {
-  "ConnectionStrings": {
-    "Kraken": "Host=postgres;Database=Kbot;Username=postgres;Password=NotYourK3yNotYourCoin$"
-  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",

--- a/src/Kbot.MailService/secrets-template.json
+++ b/src/Kbot.MailService/secrets-template.json
@@ -1,4 +1,7 @@
 {
+    "ConnectionStrings": {
+        "Kraken": "Host=kraken-database;Database=Kbot;Username=postgres;Password=<CHANGE_ME - must match POSTGRES_PASSWORD in docker/stack.env>"
+    },
     "Secrets": {
         "ApiKey": "<kraken api public key",
         "ApiSecret": "<kraken api private key>"

--- a/src/docker.mail.secrets-template.json
+++ b/src/docker.mail.secrets-template.json
@@ -1,4 +1,7 @@
 {
+    "ConnectionStrings": {
+        "Kraken": "Host=kraken-database;Database=Kbot;Username=postgres;Password=<CHANGE_ME - must match POSTGRES_PASSWORD in docker/stack.env>"
+    },
     "Secrets": {
         "ApiKey": "<kraken api public key",
         "ApiSecret": "<kraken api private key>"

--- a/test/Kbot.MailService.Test/ConnectionStringGuardTest.cs
+++ b/test/Kbot.MailService.Test/ConnectionStringGuardTest.cs
@@ -1,0 +1,65 @@
+using Kbot.MailService.Database;
+using Kbot.MailService.Utility;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Kbot.MailService.Test;
+
+/// <summary>
+/// The database connection string used to be baked into <c>appsettings.json</c> (H-11), so a missing
+/// configuration value silently fell back to a password published on GitHub. It is now required, and
+/// these tests pin the fail-fast behaviour that replaced the fallback.
+/// </summary>
+[TestClass]
+public class ConnectionStringGuardTest
+{
+  [TestMethod]
+  public void Setup_WithoutConnectionString_ThrowsNamingTheSetting()
+  {
+    var configuration = new ConfigurationBuilder().Build();
+
+    var exception = Assert.ThrowsExactly<InvalidOperationException>(() =>
+      new ServiceCollection().Setup(configuration)
+    );
+
+    StringAssert.Contains(
+      exception.Message,
+      "ConnectionStrings:Kraken",
+      "The message has to name the setting the operator must supply."
+    );
+  }
+
+  [TestMethod]
+  public void Setup_WithBlankConnectionString_ThrowsNamingTheSetting()
+  {
+    var configuration = new ConfigurationBuilder()
+      .AddInMemoryCollection([new KeyValuePair<string, string?>("ConnectionStrings:Kraken", "  ")])
+      .Build();
+
+    var exception = Assert.ThrowsExactly<InvalidOperationException>(() =>
+      new ServiceCollection().Setup(configuration)
+    );
+
+    StringAssert.Contains(exception.Message, "ConnectionStrings:Kraken");
+  }
+
+  [TestMethod]
+  public void Setup_WithConnectionString_RegistersTheServices()
+  {
+    var configuration = new ConfigurationBuilder()
+      .AddInMemoryCollection([
+        new KeyValuePair<string, string?>(
+          "ConnectionStrings:Kraken",
+          "Host=kraken-database;Database=Kbot;Username=postgres;Password=irrelevant"
+        ),
+      ])
+      .Build();
+
+    var services = new ServiceCollection().Setup(configuration);
+
+    Assert.IsTrue(
+      services.Any(s => s.ServiceType == typeof(MigrationService)),
+      "A configured connection string must let the mail service compose normally."
+    );
+  }
+}


### PR DESCRIPTION
Implements [docs/plans/p1-08-h11-database-credentials-exposure.md](docs/plans/p1-08-h11-database-credentials-exposure.md). Closes **H-11**.

Rebased onto `review-and-fix` after P1-03 (#45) merged; the only conflict was in the shared close-out docs (`docs/HANDOFF.md`), resolved by keeping P1-03's rows verbatim and re-applying P1-08's on top.

## What changed

- **[docker/example-compose.yaml](docker/example-compose.yaml)** — the `ports: - "5432:5432"` block is gone from `kraken-database`. `mail-service` reaches the database by service name over the compose network, so no host port is needed; a loopback-only `# - "127.0.0.1:5432:5432"` is left commented out for local debugging with a one-line warning.
- **[docker/stack.env](docker/stack.env)** — `ConnectionStrings__Kraken` is removed (it was a secret in a committed file, and being an env var it would have overridden the docker secret anyway). `POSTGRES_PASSWORD` stays, because the postgres image only accepts its password as an environment variable, but as the placeholder `<CHANGE_ME>`, with a comment block saying the file is committed, that real secrets belong in the docker secret files, and that the two passwords must match.
- **[src/docker.mail.secrets-template.json](src/docker.mail.secrets-template.json)** and **[src/Kbot.MailService/secrets-template.json](src/Kbot.MailService/secrets-template.json)** — document `ConnectionStrings:Kraken` as the recommended location for the credential (docker secret for the stack, user secrets for local development, since `appsettings.json` no longer carries a fallback).
- **[src/Kbot.MailService/appsettings.json](src/Kbot.MailService/appsettings.json)** — the `ConnectionStrings` block is removed entirely, so the password is no longer baked into the published image.
- **[src/Kbot.MailService/Utility/ServiceCollectionExtension.cs](src/Kbot.MailService/Utility/ServiceCollectionExtension.cs)** — explicit null/empty guard before `AddDbContextFactory`: an absent or blank `ConnectionStrings:Kraken` throws `InvalidOperationException` naming the setting and where to put it, instead of letting Npgsql fail later.
- **[README.md](README.md)** — three-line note under Installation: set your own password in both places before first start.
- **[test/Kbot.MailService.Test/ConnectionStringGuardTest.cs](test/Kbot.MailService.Test/ConnectionStringGuardTest.cs)** — new: missing and blank connection strings both fail fast with a message naming the setting; a configured one composes normally.

## ⚠️ Operator action required — rotate the password

Anyone who already deployed with the shipped default is running a Postgres instance whose password was published in this repository. Removing it from the repo does **not** change a database that already exists. Those users must set a new password in `POSTGRES_PASSWORD` **and** in the mail-service connection string and recreate the stack (or `ALTER USER postgres WITH PASSWORD …` on the running volume). That is an operator action; no code change can do it.

Deliberately **not** rewriting git history to purge the password. It stays reachable in old commits, in `REVIEW.md`'s finding text and in the plan file. Recording the decision: it is a documented default rather than a live credential of any single deployment, every reachable copy is now a placeholder or a historical reference, and a force-pushed history rewrite on a public repo costs every fork more than it buys. Rotation is the mitigation.

## Verified (on the rebased tree)

- `dotnet build Kbot.sln -warnaserror` — clean, 0 warnings.
- `dotnet test Kbot.sln` — 49 tests pass, 0 failed, 0 skipped (`.runsettings` default filter; `KBOT_ALLOW_LIVE_TRADING` never set).
- `csharpier check .` — clean, 76 files.
- `docker compose -f docker/example-compose.yaml config` — valid, and `grep ports/published` on the rendered config returns nothing for any service.
- `git grep -n 'NotYourK3y' -- ':!REVIEW.md' ':!docs/'` — clean. Every shipped file is free of it; the only remaining matches are the `REVIEW.md` finding text (the historical record, which the close-out protocol says to leave alone) and this plan's own Problem and Verification sections, which quote the literal to describe the bug.

## Left out (owned elsewhere)

- Rotating an already-deployed password → operator action, see above. The breaking-change CHANGELOG entry belongs to **P5-02**.
- `depends_on` / healthcheck for `kraken-database`, and pinning `postgres:latest` → **P4-06** (M-17, M-21). This PR touches only the `ports` block, so P4-06's diff on the same file stays trivial — and merging this unblocks it.
- The larger README rewrite → **P5-01**; only the three-line password note was added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)