### PR TITLE
fix: P1-03 clamp the top-up day and persist state before bookkeeping (C-4)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -185,6 +185,12 @@ var balanceFiat = fiatBalance - ReserveFiat;
 
 ### C-4 · `DefaultTopupDayOfMonth` 29–31 throws *after* the order is sent but *before* state is saved → duplicate buys
 
+> ✅ **Resolved** by [P1-03](docs/plans/p1-03-c4-topup-day-clamp-and-state-order.md), merged as PR #45.
+> All three date constructions go through a helper that clamps the day to the month's length and
+> stamps `DateTimeKind.Utc`, the month rollover no longer special-cases December, the validator
+> accepts 1–28 with a message that says why, and `InvestmentCycle` persists the state immediately
+> after a successful order — before anything that could throw.
+
 **Files:** [TimeComputeService.cs:10,25,29](src/Kbot.DcaService/Utility/TimeComputeService.cs#L10) · [BalanceOptions.cs:16](src/Kbot.DcaService/Options/BalanceOptions.cs#L16) · [DcaWorker.cs:49,100-107](src/Kbot.DcaService/DcaWorker.cs#L100-L107)
 
 All three `new DateTime(...)` calls pass `topUpDayOfMonth` unvalidated against the target month's length; `new DateTime(2026, 4, 31)` and `new DateTime(2026, 2, 30)` both throw `ArgumentOutOfRangeException`. `BalanceOptionsValidator` accepts anything in **1–31**, so this is a legal configuration. (Note `MailOptionsValidator` correctly caps the same concept at 28 — the two services disagree.)

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -14,13 +14,13 @@ then follow §8 to produce the next handoff.
 |---|---|
 | Repo | `dotnet-kraken-dca-bot` — a .NET 10 Kraken DCA bot (6 projects: `Kbot.Common`, `Kbot.DcaService`, `Kbot.MailService` + 3 test projects) |
 | What exists | A full code review ([REVIEW.md](../REVIEW.md)), a phased roadmap ([ROADMAP.md](ROADMAP.md)) and 37 branch-sized implementation plans ([plans/](plans/)) |
-| What has been fixed | **3 of 64 findings.** C-1 (P1-01) and C-2 / C-3 (P1-02) are merged. The rest are open. |
+| What has been fixed | **4 of 64 findings.** C-1 (P1-01), C-2 / C-3 (P1-02) and C-4 (P1-03) are merged. The rest are open. |
 | Branch state | `main` = upstream, untouched. `review-and-fix` = `main` + the review + these docs, and **the integration branch all work merges into**. P1-01 (`58c2262`) and P1-02 (#43) have landed there; everything else is still open. |
 
 **The one thing to know:** the review's verdict is *"not safe to run unattended with real money until
 C-1 … C-5 are fixed."* Those five findings are owned by plans **P1-01, P1-02, P1-03, P1-04**. They are
-all in Wave 0 and they are the point of this handoff. C-1, C-2 and C-3 are closed; **C-4 and C-5
-(P1-03, P1-04) are what is left before the bot is safe.**
+all in Wave 0 and they are the point of this handoff. C-1, C-2, C-3 and C-4 are closed; **C-5
+(P1-04) is what is left before the bot is safe.**
 
 ---
 
@@ -66,7 +66,7 @@ If you ever see a plan or an older doc say "base on `main`", it is stale — thi
 |---|---|---|---|---|
 | ~~1~~ | ~~[P1-01](plans/p1-01-c1-gate-live-trading-tests.md)~~ ✅ merged | `test/p1-c1-gate-live-trading-tests` | **C-1** | S |
 | ~~2~~ | ~~[P1-02](plans/p1-02-c2-c3-guard-worker-sentinels.md)~~ ✅ merged | `fix/p1-c2-c3-guard-worker-sentinels` | **C-2, C-3** | S |
-| 3 | [P1-03](plans/p1-03-c4-topup-day-clamp-and-state-order.md) | `fix/p1-c4-topup-day-clamp-and-state-order` | **C-4** | S |
+| ~~3~~ | ~~[P1-03](plans/p1-03-c4-topup-day-clamp-and-state-order.md)~~ ✅ merged | `fix/p1-c4-topup-day-clamp-and-state-order` | **C-4** | S |
 | 4 | [P1-04](plans/p1-04-c5-worker-loop-resilience.md) | `fix/p1-c5-worker-loop-resilience` | **C-5** | S |
 | 5 | [P1-06](plans/p1-06-h4-dockerignore-and-secret-copy.md) | `fix/p1-h4-dockerignore-and-secret-copy` | H-4 | S |
 | 6 | [P1-07](plans/p1-07-h10-tighten-options-validators.md) | `fix/p1-h10-tighten-options-validators` | H-10 | S |
@@ -81,13 +81,13 @@ to have no prerequisites — take it only if capacity is left over.
 
 Development is parallel; **merging** has two ordering constraints, both from shared files:
 
-- `src/Kbot.DcaService/DcaWorker.cs` → merge **P1-02 → P1-03 → P1-04** (P1-02 is merged)
+- `src/Kbot.DcaService/DcaWorker.cs` → merge **P1-02 → P1-03 → P1-04** (P1-02 and P1-03 are merged)
 - `src/Kbot.DcaService/Utility/TimeComputeService.cs` → planned **P1-03 → P1-02**; P1-02 got there
-  first
+  first, and both are now merged
 
 The suggested merge order for the critical four was **P1-03 → P1-02 → P1-04**, but P1-02 merged
-first, so **P1-03 and P1-04 build on it** — it is already in `DcaWorker.cs` and
-`TimeComputeService.cs`, and branching from `review-and-fix` picks it up.
+first, so **P1-03 built on it** and **P1-04 rebases onto both** — they are already in `DcaWorker.cs`
+and `TimeComputeService.cs`, and branching from `review-and-fix` picks them up.
 P1-01 was independent and is merged, which is what makes the suite safe for everyone else.
 Each conflict is a small local edit; rebasing is a two-minute job, not a redesign.
 
@@ -166,7 +166,7 @@ Rules:
 </details>
 
 <details>
-<summary><b>P1-03 · Clamp the top-up day, persist state before bookkeeping (C-4)</b></summary>
+<summary><b>P1-03 · Clamp the top-up day, persist state before bookkeeping (C-4) — ✅ merged as #45, nothing to do</b></summary>
 
 ```
 Work in the repo dotnet-kraken-dca-bot.
@@ -288,9 +288,9 @@ also no WaitOptions section in appsettings.json, so an omitted env var is silent
 tightening the validators, adding safe defaults, and unit-testing every rule (there is zero
 validator coverage today, which is how this survived).
 
-Conflict note: P1-03 also edits BalanceOptions.cs — if it is already merged, leave its
-DefaultTopupDayOfMonth rule alone. P1-02 already added the Enum.IsDefined check on
-OrderOptions.Type; do not add a second one.
+Conflict note: P1-03 is merged, so BalanceOptions.cs already validates DefaultTopupDayOfMonth as
+1-28 and TopUpDayClampTest.cs already covers that rule — leave both alone. P1-02 already added the
+Enum.IsDefined check on OrderOptions.Type; do not add a second one.
 
 Rules:
 - Stay in scope. Do not fix findings the plan lists as belonging to another plan.
@@ -446,7 +446,7 @@ Every PR updates its own row, on its own branch, before it is opened — see
 |---|---|---|---|---|
 | P1-01 | `test/p1-c1-gate-live-trading-tests` | ✅ resolved | #42 | `58c2262` (2026-08-22) |
 | P1-02 | `fix/p1-c2-c3-guard-worker-sentinels` | ✅ resolved | #43 | via #43 |
-| P1-03 | `fix/p1-c4-topup-day-clamp-and-state-order` | — | | |
+| P1-03 | `fix/p1-c4-topup-day-clamp-and-state-order` | ✅ resolved | #45 | via #45 |
 | P1-04 | `fix/p1-c5-worker-loop-resilience` | — | | |
 | P1-06 | `fix/p1-h4-dockerignore-and-secret-copy` | — | | |
 | P1-07 | `fix/p1-h10-tighten-options-validators` | — | | |
@@ -455,7 +455,7 @@ Every PR updates its own row, on its own branch, before it is opened — see
 | P2-02 | `fix/p2-h1-invariant-culture` | — | | |
 
 **Milestone M1 ("safe to run") is reached when P1-01, P1-02, P1-03 and P1-04 are all merged.**
-P1-01 and P1-02 are merged; **P1-03 and P1-04 are the two still to be written.**
+P1-01, P1-02 and P1-03 are merged; **P1-04 is the last one.**
 
 ---
 
@@ -466,9 +466,9 @@ Each merge unlocks specific plans. From [ROADMAP.md](ROADMAP.md) §4:
 | When this merges | These become ready |
 |---|---|
 | ✅ P1-01 *(merged)* | **P1-05** (`ci/p1-h3-build-test-lint-pipeline`) — **now ready**; CI could not be wired up before the tests were safe |
-| P1-03 | **P1-10** (`test/p1-h12-deterministic-timecompute-tests`) |
+| ✅ P1-03 *(merged)* | **P1-10** (`test/p1-h12-deterministic-timecompute-tests`) — **now ready**; the clamp it has to assert is in |
 | ✅ P1-02 *(merged)* **and** P1-04 | **P2-01** (`refactor/p2-i1-kraken-result-protocol`) — the highest-value change in the review; now waiting on P1-04 alone |
-| P1-03 **and** P1-07 | **P2-08** (`refactor/p2-i5-shared-trading-options`) |
+| ✅ P1-03 *(merged)* **and** P1-07 | **P2-08** (`refactor/p2-i5-shared-trading-options`) — now waiting on P1-07 alone |
 | P1-08 | **P4-06** (`fix/p4-m17-m21-startup-and-healthchecks`) |
 | P1-05 | **P2-09** (`ci/p2-workflow-hardening`) |
 | P2-02 | **P2-03** (`refactor/p2-h2-decimal-money`) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -146,7 +146,7 @@ merge order matters (see the note below) but their *development* does not.
 |---|---|---|
 | ~~P1-01~~ ✅ merged | `test/p1-c1-gate-live-trading-tests` | C-1 |
 | ~~P1-02~~ ✅ merged | `fix/p1-c2-c3-guard-worker-sentinels` | C-2, C-3 |
-| P1-03 | `fix/p1-c4-topup-day-clamp-and-state-order` | C-4 |
+| ~~P1-03~~ ✅ merged | `fix/p1-c4-topup-day-clamp-and-state-order` | C-4 |
 | P1-04 | `fix/p1-c5-worker-loop-resilience` | C-5 |
 | P1-06 | `fix/p1-h4-dockerignore-and-secret-copy` | H-4 |
 | P1-07 | `fix/p1-h10-tighten-options-validators` | H-10 |
@@ -154,21 +154,21 @@ merge order matters (see the note below) but their *development* does not.
 | P1-09 | `fix/p1-m16-redact-secrets-in-logs` | M-16 |
 | P2-02 | `fix/p2-h1-invariant-culture` | H-1 |
 
-> **`DcaWorker.cs` merge order: P1-02 → P1-03 → P1-04.** P1-02 is merged, so P1-03 and P1-04 build
-> on it. Each is a small, local edit; rebasing is a two-minute job.
+> **`DcaWorker.cs` merge order: P1-02 → P1-03 → P1-04.** P1-02 and P1-03 are merged, so P1-04 builds
+> on both. Each is a small, local edit; rebasing is a two-minute job.
 >
-> **`TimeComputeService.cs`** is touched by P1-02 (divisor guard, merged) and P1-03 (date clamp) —
-> same note.
+> **`TimeComputeService.cs`** is touched by P1-02 (divisor guard, merged) and P1-03 (date clamp,
+> merged) — nothing in Wave 0 is still waiting on that file.
 
 ### Wave 1 — unlocked by Wave 0
 
 | Plan | Unlocked by | Branch |
 |---|---|---|
 | P1-05 | P1-01 | `ci/p1-h3-build-test-lint-pipeline` |
-| P1-10 | P1-03 | `test/p1-h12-deterministic-timecompute-tests` |
+| P1-10 | ✅ P1-03 *(merged — ready)* | `test/p1-h12-deterministic-timecompute-tests` |
 | P2-01 | ✅ P1-02 + P1-04 (waiting on P1-04) | `refactor/p2-i1-kraken-result-protocol` |
 | P2-03 | P2-02 | `refactor/p2-h2-decimal-money` |
-| P2-08 | P1-03 + P1-07 | `refactor/p2-i5-shared-trading-options` |
+| P2-08 | ✅ P1-03 + P1-07 (waiting on P1-07) | `refactor/p2-i5-shared-trading-options` |
 | P2-09 | P1-05 | `ci/p2-workflow-hardening` |
 | P4-01 | — (soft: P3-01) | `refactor/p4-h6-json-state-store` |
 | P4-02 | — (soft: P3-01) | `fix/p4-h7-holiday-cache-resilience` |
@@ -224,7 +224,7 @@ Every finding in REVIEW.md, with its owning plan. Use this to check nothing was 
 | C-1 ✅ | P1-01 *(merged)* | M-1 | P4-08 |
 | C-2 ✅ | P1-02 *(merged)* (→ P2-01) | M-2 | P4-09 |
 | C-3 ✅ | P1-02 *(merged)* (→ P2-01) | M-3 | P2-05 |
-| C-4 | P1-03 | M-4 | P4-09 |
+| C-4 ✅ | P1-03 *(merged)* | M-4 | P4-09 |
 | C-5 | P1-04 | M-5 | P4-09 |
 | H-1 | P2-02 | M-6 | P4-09 |
 | H-2 | P2-03 | M-7 | P4-08 |
@@ -268,7 +268,7 @@ order up front.
 | `src/Kbot.DcaService/DcaWorker.cs` | P1-02, P1-03, P1-04, P2-01, P2-05, P3-02, P4-09 | P1-02 → P1-03 → P1-04 → P2-01 → P2-05 → P3-02 → P4-09 |
 | `src/Kbot.Common/Api/KrakenClient.cs` | P1-02, P2-01, P2-02, P2-03, P2-05, P2-06, P4-03, P4-04 | P1-02 → P2-02 → P2-01 → P2-03 → P2-06 → P2-05 → P4-03 → P4-04 |
 | `src/Kbot.Common/Api/KrakenApi.cs` | P1-09, P4-03, P4-04, P4-05, P4-10 | P1-09 → P4-05 → P4-03 → P4-04 → P4-10 |
-| `src/Kbot.DcaService/Utility/TimeComputeService.cs` | P1-02, P1-03, P1-10, P3-01, P3-02 | P1-03 → P1-02 → P1-10 → P3-01 → P3-02 |
+| `src/Kbot.DcaService/Utility/TimeComputeService.cs` | P1-02, P1-03, P1-10, P3-01, P3-02 | P1-02 ✅ → P1-03 ✅ → P1-10 → P3-01 → P3-02 (both merged; P1-10 is next) |
 | `src/Kbot.MailService/Utility/MailSenderService.cs` | P2-05, P2-07, P4-07, P4-08 | P2-07 → P2-05 → P4-08 → P4-07 |
 | `src/Kbot.MailService/Utility/OrderService.cs` | P2-01, P2-04, P2-06, P4-08 | P2-01 → P2-06 → P2-04 → P4-08 |
 | `src/Kbot.MailService/Migrations/**` | P2-03, P2-04 | P2-03 → P2-04 (**never in parallel** — two pending migrations conflict) |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -109,7 +109,7 @@ the Resolution section what you left out and which plan owns it.
 | **Phase 1 — stop the bleeding** ||||
 | P1-01 ✅ | C-1 | Gate the live-trading tests *(resolved — `58c2262`)* | `test/p1-c1-gate-live-trading-tests` |
 | P1-02 ✅ | C-2, C-3 | Guard the Kraken sentinel call sites *(resolved — #43)* | `fix/p1-c2-c3-guard-worker-sentinels` |
-| P1-03 | C-4 | Clamp the top-up day, persist state before bookkeeping | `fix/p1-c4-topup-day-clamp-and-state-order` |
+| P1-03 ✅ | C-4 | Clamp the top-up day, persist state before bookkeeping *(resolved — #45)* | `fix/p1-c4-topup-day-clamp-and-state-order` |
 | P1-04 | C-5 | Worker loop resilience and backoff | `fix/p1-c5-worker-loop-resilience` |
 | P1-05 | H-3 | CI: build, test, format gate | `ci/p1-h3-build-test-lint-pipeline` |
 | P1-06 | H-4 | Fix the inert `.dockerignore` and the `secrets.json` copy | `fix/p1-h4-dockerignore-and-secret-copy` |

--- a/docs/plans/p1-03-c4-topup-day-clamp-and-state-order.md
+++ b/docs/plans/p1-03-c4-topup-day-clamp-and-state-order.md
@@ -2,6 +2,7 @@
 
 |  |  |
 |---|---|
+| **Status** | ✅ **Resolved** — merged into `review-and-fix` via PR #45 |
 | **Findings** | C-4 |
 | **Phase** | 1 — Stop the bleeding |
 | **Branch** | `fix/p1-c4-topup-day-clamp-and-state-order` |
@@ -92,3 +93,63 @@ dotnet build Kbot.sln -warnaserror
 dotnet test Kbot.sln --filter "TestCategory!=LiveExchange&TestCategory!=LiveApi"
 dotnet csharpier check .
 ```
+
+---
+
+## Resolution
+
+Merged into `review-and-fix` from `fix/p1-c4-topup-day-clamp-and-state-order` as PR #45. **C-4 is
+closed**: no `topUpDayOfMonth` can throw a date out of existence any more, and a sent order is on
+disk before anything that could throw runs, so a crash-restart can no longer replay a buy.
+
+What landed:
+
+- [TimeComputeService.cs](../../src/Kbot.DcaService/Utility/TimeComputeService.cs) — `AtDayOfMonth`
+  clamps the day to `DateTime.DaysInMonth(year, month)` and stamps `DateTimeKind.Utc`; all three
+  date constructions go through it.
+- [TimeComputeService.cs](../../src/Kbot.DcaService/Utility/TimeComputeService.cs) — the rollover is
+  computed from the first of the month plus `AddMonths(1)`, so the hand-written December branch is
+  gone and the year boundary is no longer a special case.
+- [BalanceOptions.cs](../../src/Kbot.DcaService/Options/BalanceOptions.cs) — the validator accepts
+  **1–28** and the failure message says why 29–31 is refused. The clamp stays as defence in depth
+  for values that reach the service from a persisted state file or a config source that does not run
+  the validator. This also puts `BalanceOptions` and `MailOptions` on the same range, which is what
+  P2-08 needs.
+- [DcaWorker.cs](../../src/Kbot.DcaService/DcaWorker.cs) — `InvestmentCycle` calls `State.Save()`
+  immediately after a successful order, before `ComputeTimeUntilNextTopUp`. The `Save()` in
+  `ExecuteAsync` stays and is idempotent.
+
+One knock-on the scope did not spell out: the healthy-cycle test from P1-02 now goes through
+`DcaStateHandler.Save`, which writes to a path relative to the working directory, so
+[InvestmentCycleGuardTest.cs](../../test/Kbot.DcaService.Test/InvestmentCycleGuardTest.cs) gained a
+`[ClassInitialize]` that creates the `state` directory in the test output directory.
+
+Tests:
+
+- [TopUpDayClampTest.cs](../../test/Kbot.DcaService.Test/TopUpDayClampTest.cs) — sweeps 12 months ×
+  days {1, 28, 29, 30, 31} over a non-leap and a leap year, from the first of the month and from its
+  last evening so both date-construction sites are hit, asserting no throw, `Kind == Utc`, never a
+  weekend and never a date in the past. It then pins the exact result for February (leap and
+  non-leap), April and December, the month rollover into a short month, and the December → January
+  rollover. Hermetic: the holiday cache is seeded empty and every case sits in a past year, so there
+  is no network call and no dependency on today's date. It also covers the validator — day 31 and
+  day 0 are rejected, day 28 still passes.
+- [InvestmentCyclePersistOrderTest.cs](../../test/Kbot.DcaService.Test/InvestmentCyclePersistOrderTest.cs)
+  — one cycle against a stubbed transport in a temporary working directory with the post-order
+  bookkeeping forced to throw: `state/state.json` must already carry the post-order
+  `LastInvestmentTime`. The counter-test asserts that a skipped cycle writes nothing.
+
+Verified: `dotnet build Kbot.sln -warnaserror` clean, 46 tests pass under the default filter,
+`csharpier check .` clean.
+
+Deliberately not done: `TimeProvider` injection and the still calendar-dependent tests in
+`TimeComputeTest` → **P1-10**. One shared day-of-month option across both services → **P2-08**.
+Atomic state writes → **P4-01**. The remaining send↔persist crash window (M-6) → **P4-09**.
+
+Noted while here, not fixed: `DcaStateHandler.Save` throws if the `state` directory is missing and
+its `catch` retries with `File.Delete` on the same missing path — production creates `/app/state` in
+the Dockerfile, but this is now on the path a successful order takes and looks like the cause of
+issue #23 (**P4-01** owns that file). `HolidayService.IsHoliday` throws on an empty holiday cache,
+i.e. when the startup fetch failed (**P4-02**).
+
+Follow-ups unblocked: **P1-10**; **P2-08** once P1-07 lands.

--- a/docs/plans/p1-07-h10-tighten-options-validators.md
+++ b/docs/plans/p1-07-h10-tighten-options-validators.md
@@ -43,8 +43,9 @@ There is no `WaitOptions` section in
    - `MinWaitTime <= MaxWaitTime` (keep)
    - a lower bound on `MinWaitTime` that respects Kraken's rate limits — recommend `>= 1s`, and log a
      warning below 5 s
-3. `BalanceOptionsValidator`: keep `ReserveFiat >= 0` (0 is legitimate), and align
-   `DefaultTopupDayOfMonth` with **P1-03** (1–28). If P1-03 is already merged, leave that rule alone.
+3. `BalanceOptionsValidator`: keep `ReserveFiat >= 0` (0 is legitimate). **P1-03 is merged**, so
+   `DefaultTopupDayOfMonth` is already validated as 1–28 and already has test coverage in
+   `TopUpDayClampTest.cs` — leave that rule and its test alone.
 4. `CultureOptionsValidator`: keep as is here — the `CultureInfo`/`CountyCode` validation belongs to
    **P4-10** (M-15).
 5. Add **every** section with safe defaults to `src/Kbot.DcaService/appsettings.json` so an omitted

--- a/docs/plans/p1-10-h12-deterministic-timecompute-tests.md
+++ b/docs/plans/p1-10-h12-deterministic-timecompute-tests.md
@@ -6,7 +6,7 @@
 | **Phase** | 1 — Stop the bleeding |
 | **Branch** | `test/p1-h12-deterministic-timecompute-tests` |
 | **Effort** | M (~4 h) |
-| **Depends on** | **P1-03** (same file, and the tests must assert the clamped behaviour). Soft dependency on **P1-02** (divisor guard tests live here too). |
+| **Depends on** | ✅ **P1-03** — merged (#45), so this is **ready**. The clamp is in and `TopUpDayClampTest.cs` already covers it hermetically for 12 months × days {1, 28, 29, 30, 31}; this plan makes the *existing* `TimeComputeTest` deterministic and can fold that file in. Soft dependency on **P1-02** (divisor guard tests live here too). |
 | **Blocks** | P3-01 (extends the same `TimeProvider` seam), P3-03 |
 | **Conflict surface** | `src/Kbot.DcaService/Utility/TimeComputeService.cs` (also P1-02, P1-03), `test/Kbot.DcaService.Test/TimeComputeTest.cs` |
 

--- a/docs/plans/p2-08-i5-shared-trading-options.md
+++ b/docs/plans/p2-08-i5-shared-trading-options.md
@@ -6,7 +6,7 @@
 | **Phase** | 2 — Contract & numeric correctness |
 | **Branch** | `refactor/p2-i5-shared-trading-options` |
 | **Effort** | M (~5 h) |
-| **Depends on** | **P1-03** (day-of-month clamp/validator), **P1-07** (validator tightening) |
+| **Depends on** | ✅ **P1-03** — merged (#45); **P1-07** (validator tightening) is the one still open |
 | **Blocks** | — (but **P2-05** consumes it; coordinate whichever lands second) |
 | **Conflict surface** | `src/Kbot.Common/Options/**`, `src/Kbot.DcaService/Options/**`, `src/Kbot.MailService/Options/MailOptions.cs`, both `ServiceCollectionExtension.cs`, `docker/stack.env` (also P1-08, P4-10) |
 
@@ -18,11 +18,13 @@ The same values are configured twice under different names, with no cross-check:
 |---|---|---|
 | Trading pair | `OrderOptions__CryptoPair="XBTCHF"` | `MailOptions__CryptoPair="XBTCHF"` |
 | Fiat currency | `CultureOptions__Fiat="CHF"` | `MailOptions__Fiat="CHF"` |
-| Day-of-month | `BalanceOptions__DefaultTopupDayOfMonth` — validated **1–31** ❌ | `MailOptions__DayOfMonth` — validated **1–28** ✅ |
+| Day-of-month | `BalanceOptions__DefaultTopupDayOfMonth` — validated **1–28** since P1-03 ✅ | `MailOptions__DayOfMonth` — validated **1–28** ✅ |
 
 Change one and the reports silently disagree with the trades. The day-of-month divergence is the live
 bug behind **C-4**: the two validators encode different beliefs about the same concept and the more
-permissive one crashes.
+permissive one crashes. P1-03 has since put both on 1–28 and made the computation clamp, so the
+divergence is no longer a crash — but it is still two options for one concept, which is what this
+plan removes.
 
 Also: `CultureOptions` lives in `Kbot.Common` and `HolidayService` (also Common) depends on it — but
 only `Kbot.DcaService` registers either, so wiring `HolidayService` into MailService would fail at

--- a/src/Kbot.DcaService/DcaWorker.cs
+++ b/src/Kbot.DcaService/DcaWorker.cs
@@ -146,6 +146,11 @@ public class DcaWorker(
     if (isSuccess)
     {
       State = State with { LastInvestmentTime = DateTime.UtcNow };
+      // Durable before anything else can throw: the money is already spent, so a crash between here
+      // and the loop's Save() must not reload a pre-order LastInvestmentTime and buy again (C-4).
+      // The Save() in ExecuteAsync stays and is idempotent. P4-01 makes the write atomic; P4-09
+      // closes the remaining send-to-persist crash window (M-6).
+      State.Save();
       State = computeService.ComputeTimeUntilNextTopUp(
         State,
         balanceOptions.Value.DefaultTopupDayOfMonth

--- a/src/Kbot.DcaService/Options/BalanceOptions.cs
+++ b/src/Kbot.DcaService/Options/BalanceOptions.cs
@@ -13,9 +13,16 @@ public class BalanceOptionsValidator : IValidateOptions<BalanceOptions>
   public ValidateOptionsResult Validate(string? name, BalanceOptions options)
   {
     List<string> vor = [];
-    if (options.DefaultTopupDayOfMonth < 1 || options.DefaultTopupDayOfMonth > 31)
+    // 1-28 only: 29-31 does not exist in every month, so a higher value would silently mean a
+    // different day depending on the month. TimeComputeService still clamps to the month length as
+    // defence in depth, for values that reach it from a persisted state file or a future config
+    // source that does not run this validator.
+    if (options.DefaultTopupDayOfMonth < 1 || options.DefaultTopupDayOfMonth > 28)
     {
-      vor.Add("DefaultTopupDayOfMonth must be between 1 and 31");
+      vor.Add(
+        "DefaultTopupDayOfMonth must be between 1 and 28; 29-31 is rejected because month lengths "
+          + "differ and the day would not exist in every month"
+      );
     }
     if (options.ReserveFiat < 0)
     {

--- a/src/Kbot.DcaService/Utility/TimeComputeService.cs
+++ b/src/Kbot.DcaService/Utility/TimeComputeService.cs
@@ -5,9 +5,19 @@ namespace Kbot.DcaService.Utility;
 
 public class TimeComputeService(ILogger<TimeComputeService> logger, HolidayService holidayService)
 {
+  /// <summary>
+  /// The top-up day as an instant in the given month, clamped to that month's length: day 31 in
+  /// April is the 30th and day 29-31 in a non-leap February is the 28th. Plain
+  /// <c>new DateTime(2026, 4, 31)</c> throws, and the throw used to land between a sent order and
+  /// the state write (C-4). <see cref="DateTimeKind.Utc"/> because every comparison here is against
+  /// <see cref="DateTime.UtcNow"/>.
+  /// </summary>
+  private static DateTime AtDayOfMonth(int year, int month, int day) =>
+    new(year, month, Math.Min(day, DateTime.DaysInMonth(year, month)), 0, 0, 0, DateTimeKind.Utc);
+
   public DateTime ComputeNextTopUpTime(DateTime utcNow, int topUpDayOfMonth)
   {
-    var nextTopUpTime = new DateTime(utcNow.Year, utcNow.Month, topUpDayOfMonth, 0, 0, 0);
+    var nextTopUpTime = AtDayOfMonth(utcNow.Year, utcNow.Month, topUpDayOfMonth);
 
     while (
       nextTopUpTime.DayOfWeek == DayOfWeek.Saturday
@@ -20,14 +30,18 @@ public class TimeComputeService(ILogger<TimeComputeService> logger, HolidayServi
 
     if (utcNow > nextTopUpTime)
     {
-      if (utcNow.Month == 12)
-      {
-        nextTopUpTime = new DateTime(utcNow.Year + 1, 1, topUpDayOfMonth);
-      }
-      else
-      {
-        nextTopUpTime = new DateTime(utcNow.Year, utcNow.Month + 1, topUpDayOfMonth);
-      }
+      // Rolling over through the first of the month keeps December from needing its own branch and
+      // keeps the clamp: AddMonths on the 1st can never overflow into the month after next.
+      var firstOfNextMonth = new DateTime(
+        utcNow.Year,
+        utcNow.Month,
+        1,
+        0,
+        0,
+        0,
+        DateTimeKind.Utc
+      ).AddMonths(1);
+      nextTopUpTime = AtDayOfMonth(firstOfNextMonth.Year, firstOfNextMonth.Month, topUpDayOfMonth);
     }
 
     while (

--- a/test/Kbot.DcaService.Test/InvestmentCycleGuardTest.cs
+++ b/test/Kbot.DcaService.Test/InvestmentCycleGuardTest.cs
@@ -23,6 +23,16 @@ public class InvestmentCycleGuardTest
 {
   private static readonly TimeSpan MaxWaitTime = TimeSpan.FromHours(1);
 
+  /// <summary>
+  /// A successful cycle persists the state before it does any further bookkeeping (C-4), and
+  /// <see cref="DcaStateHandler"/> writes to a path relative to the working directory. The
+  /// dedicated ordering test in <see cref="InvestmentCyclePersistOrderTest"/> uses a temporary one;
+  /// here the test output directory is enough.
+  /// </summary>
+  [ClassInitialize]
+  public static void EnsureStateDirectory(TestContext testContext) =>
+    Directory.CreateDirectory("state");
+
   private const string BalanceOfThousandFrancs =
     """{"error":[],"result":{"CHF":"1000","XXBT":"0"}}""";
   private const string BalanceWithoutFrancs = """{"error":[],"result":{"ZUSD":"1000"}}""";

--- a/test/Kbot.DcaService.Test/InvestmentCyclePersistOrderTest.cs
+++ b/test/Kbot.DcaService.Test/InvestmentCyclePersistOrderTest.cs
@@ -1,0 +1,231 @@
+using System.Text;
+using System.Text.Json;
+using Kbot.Common.Api;
+using Kbot.Common.Enums;
+using Kbot.Common.Helpers;
+using Kbot.Common.Options;
+using Kbot.DcaService.Models;
+using Kbot.DcaService.Options;
+using Kbot.DcaService.Utility;
+using Microsoft.Extensions.Logging.Abstractions;
+using MsOptions = Microsoft.Extensions.Options.Options;
+
+namespace Kbot.DcaService.Test;
+
+/// <summary>
+/// The order in which a sent order is written down (C-4). The bookkeeping that follows a successful
+/// order used to run before the state was persisted, so a throw in it unwound out of the host with
+/// the pre-order <c>LastInvestmentTime</c> still on disk: Docker restarted the container, the state
+/// file said no order had been placed, and the bot bought again.
+///
+/// <see cref="DcaStateHandler"/> writes to a path relative to the working directory, so these tests
+/// run in a temporary one and are therefore not parallelised.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class InvestmentCyclePersistOrderTest
+{
+  private const string StateFile = "state/state.json";
+
+  [TestMethod]
+  public async Task InvestmentCycle_PersistsTheOrderEvenWhenTheBookkeepingThrows()
+  {
+    var transport = new StubKrakenTransport();
+    var startedAt = DateTime.UtcNow;
+
+    var persisted = await InTemporaryWorkingDirectory(async () =>
+    {
+      // Day 0 cannot be clamped into existence, so ComputeTimeUntilNextTopUp throws exactly where
+      // the day-31-in-April bug used to. BalanceOptionsValidator rejects this value at startup; the
+      // point here is what happens if a throw reaches that call site anyway.
+      var worker = NewWorker(transport, topUpDayOfMonth: 0);
+      worker.State = new DcaState
+      {
+        LastInvestmentTime = DateTime.UtcNow.AddDays(-1),
+        // In the past, so the cycle recomputes the top-up time instead of reusing it.
+        NextTopUpTime = DateTime.UtcNow.AddDays(-1),
+        TimeUntilNextTopUp = TimeSpan.FromDays(5),
+      };
+
+      await Assert.ThrowsExactlyAsync<ArgumentOutOfRangeException>(() =>
+        worker.InvestmentCycle(CancellationToken.None)
+      );
+      return ReadState();
+    });
+
+    Assert.IsTrue(transport.SawAddOrder, "The cycle should have placed an order before throwing.");
+    Assert.IsNotNull(persisted, $"{StateFile} should have been written before the throw.");
+    Assert.IsGreaterThanOrEqualTo(
+      startedAt,
+      persisted.LastInvestmentTime,
+      "The persisted state must be the post-order one, not the state the cycle started from."
+    );
+  }
+
+  [TestMethod]
+  public async Task InvestmentCycle_LeavesTheStateAloneWhenNoOrderWasPlaced()
+  {
+    // The counter-test: a cycle that does not spend money must not move the watermark.
+    var transport = new StubKrakenTransport { Ticker = TickerError };
+
+    var persisted = await InTemporaryWorkingDirectory(async () =>
+    {
+      var worker = NewWorker(transport, topUpDayOfMonth: 26);
+      await worker.InvestmentCycle(CancellationToken.None);
+      return ReadState();
+    });
+
+    Assert.IsFalse(transport.SawAddOrder);
+    Assert.IsNull(persisted, "A skipped cycle should not have written a state file.");
+  }
+
+  private static DcaState? ReadState() =>
+    File.Exists(StateFile)
+      ? JsonSerializer.Deserialize<DcaState>(File.ReadAllText(StateFile))
+      : null;
+
+  /// <summary>
+  /// Runs <paramref name="body"/> with the process working directory pointed at a fresh temporary
+  /// directory that has the <c>state</c> subdirectory the state handler expects, and restores it
+  /// afterwards.
+  /// </summary>
+  private static async Task<T> InTemporaryWorkingDirectory<T>(Func<Task<T>> body)
+  {
+    var original = Directory.GetCurrentDirectory();
+    var temp = Directory.CreateTempSubdirectory("kbot-state-");
+    Directory.CreateDirectory(Path.Combine(temp.FullName, "state"));
+    try
+    {
+      Directory.SetCurrentDirectory(temp.FullName);
+      return await body();
+    }
+    finally
+    {
+      Directory.SetCurrentDirectory(original);
+      temp.Delete(recursive: true);
+    }
+  }
+
+  private const string BalanceOfThousandFrancs =
+    """{"error":[],"result":{"CHF":"1000","XXBT":"0"}}""";
+  private const string TickerError = """{"error":["EQuery:Unknown asset pair"]}""";
+  private const string AddOrderAccepted =
+    """{"error":[],"result":{"txid":["OAV6BB-Q2SHQ-XSCJPG"],"descr":{"order":"buy 0.00005 XBTCHF @ limit 50000.0"}}}""";
+
+  // Whole numbers only: parsing the wire values still runs under the ambient culture, and pinning
+  // that to invariant culture is P2-02.
+  private static readonly string HealthyTicker = JsonSerializer.Serialize(
+    new
+    {
+      error = Array.Empty<string>(),
+      result = new Dictionary<string, object>
+      {
+        ["XBTCHF"] = new
+        {
+          a = new[] { "50000", "1", "1" },
+          b = new[] { "49990", "2", "2" },
+          c = new[] { "49995", "1" },
+          v = new[] { "10", "20" },
+          p = new[] { "50000", "50050" },
+          t = new[] { 100, 200 },
+          l = new[] { "49000", "48000" },
+          h = new[] { "51000", "52000" },
+          o = "50000",
+        },
+      },
+    }
+  );
+
+  private static DcaWorker NewWorker(StubKrakenTransport transport, int topUpDayOfMonth)
+  {
+    var cultureOptions = MsOptions.Create(
+      new CultureOptions
+      {
+        CultureString = "de-CH",
+        CountyCode = "CH-ZH",
+        Fiat = "CHF",
+      }
+    );
+    var api = new KrakenApi(
+      NullLogger<KrakenApi>.Instance,
+      MsOptions.Create(new Secrets { ApiKey = "test-api-key", ApiSecret = "dGVzdC1zZWNyZXQ=" }),
+      transport
+    );
+    var holidayService = new HolidayService(NullLogger<HolidayService>.Instance, cultureOptions);
+    holidayService.Holidays[DateTime.UtcNow.Year] = [];
+    return new DcaWorker(
+      NullLogger<DcaWorker>.Instance,
+      new TimeComputeService(NullLogger<TimeComputeService>.Instance, holidayService),
+      new KrakenClient(NullLogger<KrakenClient>.Instance, api),
+      MsOptions.Create(
+        new OrderOptions
+        {
+          Type = OrderType.Limit,
+          Fee = 0.4,
+          MinOrderVolume = 0.00005,
+          AskMultiplier = 1.0,
+          CryptoPair = "XBTCHF",
+        }
+      ),
+      MsOptions.Create(
+        new BalanceOptions { DefaultTopupDayOfMonth = topUpDayOfMonth, ReserveFiat = 100 }
+      ),
+      cultureOptions,
+      MsOptions.Create(
+        new WaitOptions
+        {
+          MinWaitTime = TimeSpan.FromSeconds(10),
+          MaxWaitTime = TimeSpan.FromHours(1),
+        }
+      )
+    )
+    {
+      State = new DcaState
+      {
+        LastInvestmentTime = DateTime.UtcNow.AddDays(-1),
+        NextTopUpTime = DateTime.UtcNow.AddDays(5),
+        TimeUntilNextTopUp = TimeSpan.FromDays(5),
+      },
+    };
+  }
+
+  /// <summary>
+  /// Answers Kraken's balance, ticker and AddOrder endpoints from canned content and remembers
+  /// whether an order was ever sent. A copy of the stub in
+  /// <see cref="InvestmentCycleGuardTest"/>, kept local so the two files stay independent.
+  /// </summary>
+  private sealed class StubKrakenTransport : HttpMessageHandler
+  {
+    internal string Balance { get; init; } = BalanceOfThousandFrancs;
+    internal string Ticker { get; init; } = HealthyTicker;
+    internal string AddOrder { get; init; } = AddOrderAccepted;
+    internal bool SawAddOrder { get; private set; }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+      HttpRequestMessage request,
+      CancellationToken cancellationToken
+    )
+    {
+      var path = request.RequestUri!.AbsolutePath;
+      var content = path switch
+      {
+        "/0/private/Balance" => Balance,
+        "/0/public/Ticker" => Ticker,
+        "/0/private/AddOrder" => Order(),
+        _ => throw new InvalidOperationException($"Unexpected request to {path}."),
+      };
+      return Task.FromResult(
+        new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+        {
+          Content = new StringContent(content, Encoding.UTF8, "application/json"),
+        }
+      );
+    }
+
+    private string Order()
+    {
+      SawAddOrder = true;
+      return AddOrder;
+    }
+  }
+}

--- a/test/Kbot.DcaService.Test/TopUpDayClampTest.cs
+++ b/test/Kbot.DcaService.Test/TopUpDayClampTest.cs
@@ -1,0 +1,171 @@
+using Kbot.Common.Helpers;
+using Kbot.Common.Options;
+using Kbot.DcaService.Options;
+using Kbot.DcaService.Utility;
+using Microsoft.Extensions.Logging.Abstractions;
+using MsOptions = Microsoft.Extensions.Options.Options;
+
+namespace Kbot.DcaService.Test;
+
+/// <summary>
+/// The top-up day is a configured day-of-month, so it can name a day that a given month does not
+/// have: <c>new DateTime(2026, 4, 31)</c> throws, and the throw used to land after a successful
+/// order and before the state write (C-4). These tests pin the clamp down.
+///
+/// No network and no calendar dependency: the holiday cache is seeded by hand, and every case is
+/// computed for a year in the past, for which <see cref="HolidayService"/> reports no holidays.
+/// Injecting a clock and a holiday source so the *other* tests in this project stop depending on
+/// the real calendar is P1-10.
+/// </summary>
+[TestClass]
+public class TopUpDayClampTest
+{
+  /// <summary>2023 has a 28-day February, 2024 a 29-day one.</summary>
+  private static readonly int[] Years = [2023, 2024];
+
+  private static readonly int[] Days = [1, 28, 29, 30, 31];
+
+  [TestMethod]
+  public void ComputeNextTopUpTime_NeverThrowsForAnyDayOfMonthInAnyMonth()
+  {
+    var service = NewService();
+
+    foreach (var year in Years)
+    {
+      for (var month = 1; month <= 12; month++)
+      {
+        foreach (var day in Days)
+        {
+          // Both call sites: the first of the month leaves the top-up day ahead of "now", the last
+          // evening of the month puts it behind and takes the month-rollover branch.
+          DateTime[] instants =
+          [
+            new(year, month, 1, 0, 0, 0, DateTimeKind.Utc),
+            new(year, month, DateTime.DaysInMonth(year, month), 23, 0, 0, DateTimeKind.Utc),
+          ];
+          foreach (var utcNow in instants)
+          {
+            var next = service.ComputeNextTopUpTime(utcNow, day);
+
+            Assert.AreEqual(
+              DateTimeKind.Utc,
+              next.Kind,
+              $"Everything here is compared against DateTime.UtcNow ({utcNow:o}, day {day})."
+            );
+            Assert.IsGreaterThanOrEqualTo(
+              utcNow.Date,
+              next,
+              $"The next top-up must not be in the past ({utcNow:o}, day {day})."
+            );
+            Assert.IsLessThan(
+              utcNow.Date.AddDays(45),
+              next,
+              $"The next top-up is at most one month plus a weekend away ({utcNow:o}, day {day})."
+            );
+            Assert.AreNotEqual(DayOfWeek.Saturday, next.DayOfWeek);
+            Assert.AreNotEqual(DayOfWeek.Sunday, next.DayOfWeek);
+          }
+        }
+      }
+    }
+  }
+
+  [TestMethod]
+  public void ComputeNextTopUpTime_ClampsDayThirtyOneToTheMonthLength()
+  {
+    var service = NewService();
+
+    // February, leap year: the 29th exists and is a Thursday.
+    Assert.AreEqual(
+      new DateTime(2024, 2, 29, 0, 0, 0, DateTimeKind.Utc),
+      service.ComputeNextTopUpTime(new DateTime(2024, 2, 1, 0, 0, 0, DateTimeKind.Utc), 31)
+    );
+    // February, non-leap year: the 28th, a Tuesday.
+    Assert.AreEqual(
+      new DateTime(2023, 2, 28, 0, 0, 0, DateTimeKind.Utc),
+      service.ComputeNextTopUpTime(new DateTime(2023, 2, 1, 0, 0, 0, DateTimeKind.Utc), 31)
+    );
+    // April: clamped to the 30th, which is a Sunday, so the weekend skip moves it to 1 May.
+    Assert.AreEqual(
+      new DateTime(2023, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+      service.ComputeNextTopUpTime(new DateTime(2023, 4, 1, 0, 0, 0, DateTimeKind.Utc), 31)
+    );
+    // December: the 31st exists but is a Sunday, so the skip crosses into the next year.
+    Assert.AreEqual(
+      new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+      service.ComputeNextTopUpTime(new DateTime(2023, 12, 1, 0, 0, 0, DateTimeKind.Utc), 31)
+    );
+  }
+
+  [TestMethod]
+  public void ComputeNextTopUpTime_RollsOverIntoTheNextMonthAndTheNextYear()
+  {
+    var service = NewService();
+
+    // The rollover used to be a hand-written December special case; January of the next year is the
+    // only thing AddMonths on the first of the month can produce here.
+    Assert.AreEqual(
+      new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+      service.ComputeNextTopUpTime(new DateTime(2023, 12, 31, 23, 0, 0, DateTimeKind.Utc), 1)
+    );
+    // The case that threw: rolling a day-31 configuration over into February.
+    Assert.AreEqual(
+      new DateTime(2023, 2, 28, 0, 0, 0, DateTimeKind.Utc),
+      service.ComputeNextTopUpTime(new DateTime(2023, 1, 31, 23, 0, 0, DateTimeKind.Utc), 31)
+    );
+  }
+
+  [TestMethod]
+  public void BalanceOptionsValidator_RejectsADayThatDoesNotExistInEveryMonth()
+  {
+    var validator = new BalanceOptionsValidator();
+
+    var rejected = validator.Validate(
+      null,
+      new BalanceOptions { DefaultTopupDayOfMonth = 31, ReserveFiat = 0 }
+    );
+
+    Assert.IsTrue(rejected.Failed, "Day 31 does not exist in every month and must not start up.");
+    Assert.IsTrue(
+      rejected.FailureMessage!.Contains("DefaultTopupDayOfMonth")
+        && rejected.FailureMessage.Contains("28"),
+      $"The message should name the option and the accepted range, got: {rejected.FailureMessage}"
+    );
+    Assert.IsTrue(
+      validator
+        .Validate(null, new BalanceOptions { DefaultTopupDayOfMonth = 0, ReserveFiat = 0 })
+        .Failed,
+      "There is no day 0."
+    );
+    Assert.IsTrue(
+      validator
+        .Validate(null, new BalanceOptions { DefaultTopupDayOfMonth = 28, ReserveFiat = 0 })
+        .Succeeded,
+      "Day 28 exists in every month and must stay a legal configuration."
+    );
+  }
+
+  /// <summary>
+  /// A <see cref="TimeComputeService"/> whose holiday cache is seeded but empty. The seeding matters:
+  /// <see cref="HolidayService.IsHoliday"/> reads <c>Holidays.Keys.Min()</c>, which throws on an
+  /// empty cache and re-fetches over the network for a stale one.
+  /// </summary>
+  private static TimeComputeService NewService()
+  {
+    var holidayService = new HolidayService(
+      NullLogger<HolidayService>.Instance,
+      MsOptions.Create(
+        new CultureOptions
+        {
+          CultureString = "de-CH",
+          CountyCode = "CH-ZH",
+          Fiat = "CHF",
+        }
+      )
+    );
+    var thisYear = DateTime.UtcNow.Year;
+    holidayService.Holidays[thisYear] = [];
+    holidayService.Holidays[thisYear + 1] = [];
+    return new TimeComputeService(NullLogger<TimeComputeService>.Instance, holidayService);
+  }
+}


### PR DESCRIPTION
Implements [docs/plans/p1-03-c4-topup-day-clamp-and-state-order.md](docs/plans/p1-03-c4-topup-day-clamp-and-state-order.md).

**Closes finding C-4** — `DefaultTopupDayOfMonth` 29–31 threw *after* the order was sent and *before* the state was saved, so the host died, Docker restarted it, `DcaStateHandler.Load()` returned the pre-order `LastInvestmentTime` and the bot bought again. With day 31 the bot could not even start in April, June, September or November.

## What changed

- **`src/Kbot.DcaService/Utility/TimeComputeService.cs`** — new `AtDayOfMonth(year, month, day)` clamps the day to `DateTime.DaysInMonth(...)` and stamps `DateTimeKind.Utc`; all three date constructions go through it. The month rollover now goes through the first of the month plus `AddMonths(1)`, so the hand-written December branch is gone.
- **`src/Kbot.DcaService/DcaWorker.cs`** — `InvestmentCycle` calls `State.Save()` immediately after a successful order, before `ComputeTimeUntilNextTopUp` can throw. The `Save()` in `ExecuteAsync` stays and is idempotent.
- **`src/Kbot.DcaService/Options/BalanceOptions.cs`** — the validator accepts **1–28** and says why 29–31 is rejected. The clamp stays as defence in depth for values that reach the service from a persisted state file or a config source that does not run the validator.

## Tests

- `test/Kbot.DcaService.Test/TopUpDayClampTest.cs` — sweeps 12 months × days {1, 28, 29, 30, 31} over a non-leap and a leap year, from both the first of the month and its last evening (so both date-construction sites are exercised); asserts the exact clamped result for February (leap and non-leap), April and December, the month and year rollover, and `Kind == Utc`. Deliberately network-free and calendar-independent: the holiday cache is seeded empty and every case sits in a past year. Also covers the validator: day 31 and day 0 are rejected, day 28 still passes.
- `test/Kbot.DcaService.Test/InvestmentCyclePersistOrderTest.cs` — one cycle against a stubbed transport in a temporary working directory, with the post-order bookkeeping forced to throw: `state/state.json` must already hold the post-order `LastInvestmentTime`. Counter-test: a skipped cycle writes nothing.
- `test/Kbot.DcaService.Test/InvestmentCycleGuardTest.cs` — two added lines create the `state` directory, because the healthy cycle from P1-02's test now persists.

## Verified

- `dotnet build Kbot.sln -warnaserror` — clean, 0 warnings.
- `dotnet test Kbot.sln` — 46 passed, 0 failed, 0 skipped (default `.runsettings` filter; `KBOT_ALLOW_LIVE_TRADING` never set).
- `dotnet csharpier check .` — clean (75 files).

## Deliberately left out

- Sentinel guards (**P1-02**, merged) and the loop `try`/`catch` (**P1-04**) — untouched.
- Aligning `MailOptions.DayOfMonth` with `BalanceOptions.DefaultTopupDayOfMonth` into one shared option → **P2-08**. The two validators now agree on 1–28, which is what P2-08 needs.
- `TimeProvider` injection and the calendar-dependent existing tests in `TimeComputeTest` (which still call `HolidayService.StartAsync` over the network) → **P1-10**, now unblocked.
- Atomic state writes → **P4-01**; the remaining send↔persist crash window (M-6) → **P4-09**.

## Noted, not fixed

- `DcaStateHandler.Save` throws if the `state` directory does not exist, and its `catch` retries with `File.Delete` on the same missing path, which throws again. Production creates `/app/state` in the Dockerfile, so this only bites outside the container — but it is now on the path a successful order takes, and it looks like the cause of issue #23. **P4-01** owns that file.
- `HolidayService.IsHoliday` throws `InvalidOperationException` on an empty holiday cache (`Holidays.Keys.Min()`), i.e. when the remote fetch failed at startup. **P4-02**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
