### PR TITLE
fix: P1-04 worker loop resilience and backoff (C-5)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -220,6 +220,14 @@ Restrict `DefaultTopupDayOfMonth` to 1–28 in the validator unless clamping is 
 
 ### C-5 · Neither worker loop has any exception handling
 
+> ✅ **Resolved** by [P1-04](docs/plans/p1-04-c5-worker-loop-resilience.md), merged as PR #46. Both
+> `ExecuteAsync` loops now guard their body, log the caught exception with its stack trace and pace
+> the retry with a capped exponential backoff instead of letting the throw stop the host; the DCA
+> startup path runs inside that same guard, cancellation exits without an error, and the restart
+> notification mail is rate-limited to one an hour so a restart loop cannot flood the inbox. The
+> individual throws listed below are still owned by their own plans — this only guarantees the loops
+> survive them.
+
 **Files:** [DcaWorker.cs:45-58](src/Kbot.DcaService/DcaWorker.cs#L45-L58) · [DailyReporter.cs:17,19](src/Kbot.MailService/DailyReporter.cs#L17)
 
 Neither `ExecuteAsync`'s `while` body nor `InvestmentCycle` has a `try`/`catch`. Every throw identified in this review terminates the host:

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -14,13 +14,14 @@ then follow §8 to produce the next handoff.
 |---|---|
 | Repo | `dotnet-kraken-dca-bot` — a .NET 10 Kraken DCA bot (6 projects: `Kbot.Common`, `Kbot.DcaService`, `Kbot.MailService` + 3 test projects) |
 | What exists | A full code review ([REVIEW.md](../REVIEW.md)), a phased roadmap ([ROADMAP.md](ROADMAP.md)) and 37 branch-sized implementation plans ([plans/](plans/)) |
-| What has been fixed | **5 of 64 findings.** C-1 (P1-01), C-2 / C-3 (P1-02), C-4 (P1-03) and H-11 (P1-08) are merged. The rest are open. |
-| Branch state | `main` = upstream, untouched. `review-and-fix` = `main` + the review + these docs, and **the integration branch all work merges into**. P1-01 (`58c2262`), P1-02 (#43) and P1-08 (#44) have landed there; everything else is still open. |
+| What has been fixed | **6 of 64 findings.** C-1 (P1-01), C-2 / C-3 (P1-02), C-4 (P1-03), C-5 (P1-04) and H-11 (P1-08) are merged. The rest are open. |
+| Branch state | `main` = upstream, untouched. `review-and-fix` = `main` + the review + these docs, and **the integration branch all work merges into**. P1-01 (`58c2262`), P1-02 (#43), P1-03 (#45), P1-04 (#46) and P1-08 (#44) have landed there; everything else is still open. |
 
 **The one thing to know:** the review's verdict is *"not safe to run unattended with real money until
 C-1 … C-5 are fixed."* Those five findings are owned by plans **P1-01, P1-02, P1-03, P1-04**. They are
-all in Wave 0 and they are the point of this handoff. C-1, C-2, C-3 and C-4 are closed; **C-5
-(P1-04) is what is left before the bot is safe.**
+all in Wave 0 and they were the point of this handoff. **C-1 … C-5 are all closed, so Milestone M1
+("safe to run") is reached.** What is left in Wave 0 is the non-critical work: P1-06, P1-07, P1-09
+and P2-02.
 
 ---
 
@@ -67,27 +68,28 @@ If you ever see a plan or an older doc say "base on `main`", it is stale — thi
 | ~~1~~ | ~~[P1-01](plans/p1-01-c1-gate-live-trading-tests.md)~~ ✅ merged | `test/p1-c1-gate-live-trading-tests` | **C-1** | S |
 | ~~2~~ | ~~[P1-02](plans/p1-02-c2-c3-guard-worker-sentinels.md)~~ ✅ merged | `fix/p1-c2-c3-guard-worker-sentinels` | **C-2, C-3** | S |
 | ~~3~~ | ~~[P1-03](plans/p1-03-c4-topup-day-clamp-and-state-order.md)~~ ✅ merged | `fix/p1-c4-topup-day-clamp-and-state-order` | **C-4** | S |
-| 4 | [P1-04](plans/p1-04-c5-worker-loop-resilience.md) | `fix/p1-c5-worker-loop-resilience` | **C-5** | S |
+| ~~4~~ | ~~[P1-04](plans/p1-04-c5-worker-loop-resilience.md)~~ ✅ merged | `fix/p1-c5-worker-loop-resilience` | **C-5** | S |
 | 5 | [P1-06](plans/p1-06-h4-dockerignore-and-secret-copy.md) | `fix/p1-h4-dockerignore-and-secret-copy` | H-4 | S |
 | 6 | [P1-07](plans/p1-07-h10-tighten-options-validators.md) | `fix/p1-h10-tighten-options-validators` | H-10 | S |
 | ~~7~~ | ~~[P1-08](plans/p1-08-h11-database-credentials-exposure.md)~~ ✅ merged | `fix/p1-h11-database-credentials-exposure` | H-11 | S |
 | 8 | [P1-09](plans/p1-09-m16-redact-secrets-in-logs.md) | `fix/p1-m16-redact-secrets-in-logs` | M-16 | XS |
 | 9 | [P2-02](plans/p2-02-h1-invariant-culture.md) | `fix/p2-h1-invariant-culture` | H-1 | M |
 
-Rows 1–4 close the five critical findings and are the priority. Row 9 is a Phase-2 plan that happens
+Rows 1–4 closed the five critical findings and are all merged. Row 9 is a Phase-2 plan that happens
 to have no prerequisites — take it only if capacity is left over.
 
 ### Merge-order constraints inside Wave 0
 
 Development is parallel; **merging** has two ordering constraints, both from shared files:
 
-- `src/Kbot.DcaService/DcaWorker.cs` → merge **P1-02 → P1-03 → P1-04** (P1-02 and P1-03 are merged)
+- `src/Kbot.DcaService/DcaWorker.cs` → merge **P1-02 → P1-03 → P1-04** (all three are merged, in
+  that order)
 - `src/Kbot.DcaService/Utility/TimeComputeService.cs` → planned **P1-03 → P1-02**; P1-02 got there
   first, and both are now merged
 
 The suggested merge order for the critical four was **P1-03 → P1-02 → P1-04**, but P1-02 merged
-first, so **P1-03 built on it** and **P1-04 rebases onto both** — they are already in `DcaWorker.cs`
-and `TimeComputeService.cs`, and branching from `review-and-fix` picks them up.
+first, so **P1-03 built on it** and **P1-04 rebased onto both** — all of it is in `DcaWorker.cs` and
+`TimeComputeService.cs` now, and branching from `review-and-fix` picks it up.
 P1-01 was independent and is merged, which is what makes the suite safe for everyone else.
 Each conflict is a small local edit; rebasing is a two-minute job, not a redesign.
 
@@ -203,7 +205,7 @@ Rules:
 </details>
 
 <details>
-<summary><b>P1-04 · Worker loop resilience and backoff (C-5)</b></summary>
+<summary><b>P1-04 · Worker loop resilience and backoff (C-5) — ✅ merged as PR #46, nothing to do</b></summary>
 
 ```
 Work in the repo dotnet-kraken-dca-bot.
@@ -447,7 +449,7 @@ Every PR updates its own row, on its own branch, before it is opened — see
 | P1-01 | `test/p1-c1-gate-live-trading-tests` | ✅ resolved | #42 | `58c2262` (2026-08-22) |
 | P1-02 | `fix/p1-c2-c3-guard-worker-sentinels` | ✅ resolved | #43 | via #43 |
 | P1-03 | `fix/p1-c4-topup-day-clamp-and-state-order` | ✅ resolved | #45 | via #45 |
-| P1-04 | `fix/p1-c5-worker-loop-resilience` | — | | |
+| P1-04 | `fix/p1-c5-worker-loop-resilience` | ✅ resolved | #46 | via #46 |
 | P1-06 | `fix/p1-h4-dockerignore-and-secret-copy` | — | | |
 | P1-07 | `fix/p1-h10-tighten-options-validators` | — | | |
 | P1-08 | `fix/p1-h11-database-credentials-exposure` | ✅ resolved | #44 | via #44 |
@@ -455,7 +457,8 @@ Every PR updates its own row, on its own branch, before it is opened — see
 | P2-02 | `fix/p2-h1-invariant-culture` | — | | |
 
 **Milestone M1 ("safe to run") is reached when P1-01, P1-02, P1-03 and P1-04 are all merged.**
-P1-01, P1-02 and P1-03 are merged; **P1-04 is the last one.**
+All four are merged, so **M1 is reached**: no known path loses money unattended and `dotnet test`
+is safe.
 
 ---
 
@@ -467,7 +470,7 @@ Each merge unlocks specific plans. From [ROADMAP.md](ROADMAP.md) §4:
 |---|---|
 | ✅ P1-01 *(merged)* | **P1-05** (`ci/p1-h3-build-test-lint-pipeline`) — **now ready**; CI could not be wired up before the tests were safe |
 | ✅ P1-03 *(merged)* | **P1-10** (`test/p1-h12-deterministic-timecompute-tests`) — **now ready**; the clamp it has to assert is in |
-| ✅ P1-02 *(merged)* **and** P1-04 | **P2-01** (`refactor/p2-i1-kraken-result-protocol`) — the highest-value change in the review; now waiting on P1-04 alone |
+| ✅ P1-02 **and** ✅ P1-04 *(both merged)* | **P2-01** (`refactor/p2-i1-kraken-result-protocol`) — the highest-value change in the review; **now ready** |
 | ✅ P1-03 *(merged)* **and** P1-07 | **P2-08** (`refactor/p2-i5-shared-trading-options`) — now waiting on P1-07 alone |
 | ✅ P1-08 *(merged)* | **P4-06** (`fix/p4-m17-m21-startup-and-healthchecks`) — **now ready**; the compose file no longer carries the port mapping or the password |
 | P1-05 | **P2-09** (`ci/p2-workflow-hardening`) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -147,15 +147,15 @@ merge order matters (see the note below) but their *development* does not.
 | ~~P1-01~~ ✅ merged | `test/p1-c1-gate-live-trading-tests` | C-1 |
 | ~~P1-02~~ ✅ merged | `fix/p1-c2-c3-guard-worker-sentinels` | C-2, C-3 |
 | ~~P1-03~~ ✅ merged | `fix/p1-c4-topup-day-clamp-and-state-order` | C-4 |
-| P1-04 | `fix/p1-c5-worker-loop-resilience` | C-5 |
+| ~~P1-04~~ ✅ merged | `fix/p1-c5-worker-loop-resilience` | C-5 |
 | P1-06 | `fix/p1-h4-dockerignore-and-secret-copy` | H-4 |
 | P1-07 | `fix/p1-h10-tighten-options-validators` | H-10 |
 | ~~P1-08~~ ✅ merged | `fix/p1-h11-database-credentials-exposure` | H-11 |
 | P1-09 | `fix/p1-m16-redact-secrets-in-logs` | M-16 |
 | P2-02 | `fix/p2-h1-invariant-culture` | H-1 |
 
-> **`DcaWorker.cs` merge order: P1-02 → P1-03 → P1-04.** P1-02 and P1-03 are merged, so P1-04 builds
-> on both. Each is a small, local edit; rebasing is a two-minute job.
+> **`DcaWorker.cs` merge order: P1-02 → P1-03 → P1-04.** All three are merged, in that order;
+> nothing in Wave 0 is still waiting on that file.
 >
 > **`TimeComputeService.cs`** is touched by P1-02 (divisor guard, merged) and P1-03 (date clamp,
 > merged) — nothing in Wave 0 is still waiting on that file.
@@ -166,7 +166,7 @@ merge order matters (see the note below) but their *development* does not.
 |---|---|---|
 | P1-05 | P1-01 | `ci/p1-h3-build-test-lint-pipeline` |
 | P1-10 | ✅ P1-03 *(merged — ready)* | `test/p1-h12-deterministic-timecompute-tests` |
-| P2-01 | ✅ P1-02 + P1-04 (waiting on P1-04) | `refactor/p2-i1-kraken-result-protocol` |
+| P2-01 | ✅ P1-02 + P1-04 (**both merged — ready**) | `refactor/p2-i1-kraken-result-protocol` |
 | P2-03 | P2-02 | `refactor/p2-h2-decimal-money` |
 | P2-08 | ✅ P1-03 + P1-07 (waiting on P1-07) | `refactor/p2-i5-shared-trading-options` |
 | P2-09 | P1-05 | `ci/p2-workflow-hardening` |
@@ -201,7 +201,7 @@ merge order matters (see the note below) but their *development* does not.
 
 | Plan | Unlocked by | Branch |
 |---|---|---|
-| P2-07 | P2-06 + P1-04 | `fix/p2-h5-monthly-report-watermark` |
+| P2-07 | P2-06 + ✅ P1-04 | `fix/p2-h5-monthly-report-watermark` |
 | P3-02 | P3-01 | `refactor/p3-dca-planner` |
 | P4-08 | P2-03 + P2-04 | `fix/p4-reporting-correctness` |
 | P3-03 (behaviour half) | P3-01, P3-02 | `test/p3-coverage-gaps-behaviour` |
@@ -225,7 +225,7 @@ Every finding in REVIEW.md, with its owning plan. Use this to check nothing was 
 | C-2 ✅ | P1-02 *(merged)* (→ P2-01) | M-2 | P4-09 |
 | C-3 ✅ | P1-02 *(merged)* (→ P2-01) | M-3 | P2-05 |
 | C-4 ✅ | P1-03 *(merged)* | M-4 | P4-09 |
-| C-5 | P1-04 | M-5 | P4-09 |
+| C-5 ✅ | P1-04 *(merged)* | M-5 | P4-09 |
 | H-1 | P2-02 | M-6 | P4-09 |
 | H-2 | P2-03 | M-7 | P4-08 |
 | H-3 | P1-05 | M-8 | P4-08 |
@@ -265,7 +265,7 @@ order up front.
 
 | File | Plans | Suggested order |
 |---|---|---|
-| `src/Kbot.DcaService/DcaWorker.cs` | P1-02, P1-03, P1-04, P2-01, P2-05, P3-02, P4-09 | P1-02 → P1-03 → P1-04 → P2-01 → P2-05 → P3-02 → P4-09 |
+| `src/Kbot.DcaService/DcaWorker.cs` | P1-02, P1-03, P1-04, P2-01, P2-05, P3-02, P4-09 | P1-02 → P1-03 → P1-04 (all merged) → P2-01 → P2-05 → P3-02 → P4-09 |
 | `src/Kbot.Common/Api/KrakenClient.cs` | P1-02, P2-01, P2-02, P2-03, P2-05, P2-06, P4-03, P4-04 | P1-02 → P2-02 → P2-01 → P2-03 → P2-06 → P2-05 → P4-03 → P4-04 |
 | `src/Kbot.Common/Api/KrakenApi.cs` | P1-09, P4-03, P4-04, P4-05, P4-10 | P1-09 → P4-05 → P4-03 → P4-04 → P4-10 |
 | `src/Kbot.DcaService/Utility/TimeComputeService.cs` | P1-02, P1-03, P1-10, P3-01, P3-02 | P1-02 ✅ → P1-03 ✅ → P1-10 → P3-01 → P3-02 (both merged; P1-10 is next) |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -110,7 +110,7 @@ the Resolution section what you left out and which plan owns it.
 | P1-01 ✅ | C-1 | Gate the live-trading tests *(resolved — `58c2262`)* | `test/p1-c1-gate-live-trading-tests` |
 | P1-02 ✅ | C-2, C-3 | Guard the Kraken sentinel call sites *(resolved — #43)* | `fix/p1-c2-c3-guard-worker-sentinels` |
 | P1-03 ✅ | C-4 | Clamp the top-up day, persist state before bookkeeping *(resolved — #45)* | `fix/p1-c4-topup-day-clamp-and-state-order` |
-| P1-04 | C-5 | Worker loop resilience and backoff | `fix/p1-c5-worker-loop-resilience` |
+| P1-04 ✅ | C-5 | Worker loop resilience and backoff *(resolved — #46)* | `fix/p1-c5-worker-loop-resilience` |
 | P1-05 | H-3 | CI: build, test, format gate | `ci/p1-h3-build-test-lint-pipeline` |
 | P1-06 | H-4 | Fix the inert `.dockerignore` and the `secrets.json` copy | `fix/p1-h4-dockerignore-and-secret-copy` |
 | P1-07 | H-10 | Tighten the options validators | `fix/p1-h10-tighten-options-validators` |

--- a/docs/plans/p1-04-c5-worker-loop-resilience.md
+++ b/docs/plans/p1-04-c5-worker-loop-resilience.md
@@ -2,6 +2,7 @@
 
 |  |  |
 |---|---|
+| **Status** | ✅ **Resolved** — merged into `review-and-fix` via PR #46 |
 | **Findings** | C-5 |
 | **Phase** | 1 — Stop the bleeding |
 | **Branch** | `fix/p1-c5-worker-loop-resilience` |
@@ -98,3 +99,74 @@ dotnet build Kbot.sln -warnaserror
 dotnet test Kbot.sln --filter "TestCategory!=LiveExchange&TestCategory!=LiveApi"
 dotnet csharpier check .
 ```
+
+---
+
+## Resolution
+
+Merged into `review-and-fix` from `fix/p1-c5-worker-loop-resilience` as PR #46. **C-5 is closed**: no
+throw in either service can stop the host any more, so a transient fault costs a logged error and a
+paced retry instead of a container restart that reloads pre-order state and buys again.
+
+What landed:
+
+- [ExponentialBackoff.cs](../../src/Kbot.Common/Helpers/ExponentialBackoff.cs) — the shared retry
+  pacing: `Next()` doubles the delay per consecutive failure, `Reset()` returns it to the base after
+  a success, and every value stays inside `[baseDelay, maxDelay]`. The jitter fills the window
+  between the previous ceiling and the current one rather than the full `[0, ceiling]` range the plan
+  suggested: full jitter can return a delay shorter than the one before it, and the acceptance
+  criterion requires the loops to back off *monotonically*. `Random.Shared` supplies the jitter, so
+  there is no shared `Random` to synchronise.
+- [DcaWorker.cs](../../src/Kbot.DcaService/DcaWorker.cs) — the loop body is guarded, around P1-03's
+  post-order `State.Save()` rather than in place of it. A caught
+  exception is logged with the exception object and the retry delay, then paced by a backoff whose
+  floor is `WaitOptions.MinWaitTime` and whose cap is `WaitOptions.MaxWaitTime`; a successful cycle
+  resets it. `catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)` and a
+  guarded `Task.Delay` make a stop an orderly exit rather than a logged fault.
+- [DcaWorker.cs](../../src/Kbot.DcaService/DcaWorker.cs) — the startup path (`DcaStateHandler.Load()`
+  and the first `ComputeNextTopUpTime`) moved into `SeedState()` and now runs *inside* that guard on
+  the loop's first iteration, so a throw there is retried after a backoff delay instead of stopping
+  the host before the loop exists.
+- [DailyReporter.cs](../../src/Kbot.MailService/DailyReporter.cs) — `WelcomeOrRestartMessage()` and
+  `SendReportOnStartup()` are guarded individually, so a failed startup mail no longer prevents the
+  daily loop from running, and the per-iteration `SendDailyMail()` / `SendReportAsync()` pair is
+  guarded with its own backoff (1 min → 1 h) before the next attempt.
+- [RestartNoticeThrottle.cs](../../src/Kbot.MailService/Utility/RestartNoticeThrottle.cs) — the
+  restart notification is rate-limited. The simplest correct option turned out to be a marker file
+  (`state/restart-notice.json`) holding the timestamp of the last *successful* send: it survives the
+  restart it is meant to catch, which an in-memory guard cannot. A second notice inside an hour is
+  suppressed; a missing, unreadable or future-dated marker counts as "no recent send", and a marker
+  that cannot be written is a warning, never a fault.
+
+Two things the scope implied but did not spell out:
+
+- A non-positive backoff delay in `DcaWorker` falls back to one second. `WaitOptions` of `00:00:00`
+  passes validation today, and pacing a persistent fault at zero would replace a restart loop with a
+  busy loop against Kraken. `ExponentialBackoff` likewise normalises a negative base and an inverted
+  range instead of throwing — a guard that throws on bad config is not a guard.
+- `Task.Delay` is wrapped as well, not just the cycle: a stop arriving during the wait is the common
+  case, and it must exit without an error.
+
+Tests: [ExponentialBackoffTest.cs](../../test/Kbot.Common.Test/ExponentialBackoffTest.cs) pins the
+first delay, the monotonic growth, the cap, the jitter window, `Reset()`, the degenerate ranges and
+the absence of overflow.
+[WorkerLoopResilienceTest.cs](../../test/Kbot.DcaService.Test/WorkerLoopResilienceTest.cs) runs the
+real `ExecuteAsync` against a collaborator that throws on every iteration (an empty `HolidayService`
+cache — H-7, which P4-02 owns) and asserts an error with its exception per iteration, retry delays
+that never shrink and settle on `MaxWaitTime`, and a worker task that is still running; a second test
+asserts that stopping the service exits promptly, runs to completion and logs nothing.
+[RestartNoticeThrottleTest.cs](../../test/Kbot.MailService.Test/RestartNoticeThrottleTest.cs) covers
+the quiet period, the first run, a stale marker, a future-dated marker, a corrupt marker and an
+unwritable location.
+
+Verified: `dotnet build Kbot.sln -warnaserror` clean, 64 tests pass under the default filter,
+`csharpier check .` clean.
+
+Deliberately not done: the individual throws themselves — C-4 → **P1-03**, H-7 → **P4-02**,
+state-file IO → **P4-01**; watermark semantics on a failed fetch → **P2-07**;
+`CancellationToken` propagation into the Kraken client → **P4-04**; healthchecks and the dead-man's
+switch → **P4-06** and `FUTURE_FEATURES.md` F-1. The mail loop has no test driving `ExecuteAsync`
+either: `DailyReporter` depends on the concrete `MailSenderService`, which needs a database, and the
+seams for that are **P3-01** / **P3-03**.
+
+Follow-ups unblocked: **P2-01** — the last of its two prerequisites.

--- a/docs/plans/p2-01-i1-kraken-result-protocol.md
+++ b/docs/plans/p2-01-i1-kraken-result-protocol.md
@@ -6,7 +6,7 @@
 | **Phase** | 2 — Contract & numeric correctness |
 | **Branch** | `refactor/p2-i1-kraken-result-protocol` |
 | **Effort** | M (~1 day) |
-| **Depends on** | **P1-02** and **P1-04** merged (this replaces P1-02's tactical guards with a typed contract and relies on the loop being fault-tolerant) |
+| **Depends on** | ✅ **P1-02** and **P1-04** — both merged, so this is ready (it replaces P1-02's tactical guards with a typed contract and relies on the loop being fault-tolerant) |
 | **Blocks** | **P2-05**, **P2-06**, **P3-01** — and it is the single highest-value change in the review |
 | **Conflict surface** | `src/Kbot.Common/Api/KrakenClient.cs` (also P2-02, P2-03, P2-06), `src/Kbot.DcaService/DcaWorker.cs`, `src/Kbot.MailService/Utility/OrderService.cs` |
 

--- a/docs/plans/p2-07-h5-monthly-report-watermark.md
+++ b/docs/plans/p2-07-h5-monthly-report-watermark.md
@@ -6,9 +6,9 @@
 | **Phase** | 2 — Contract & numeric correctness |
 | **Branch** | `fix/p2-h5-monthly-report-watermark` |
 | **Effort** | M (~5 h) |
-| **Depends on** | **P2-06** (a fetch failure must be detectable), **P1-04** (loop must survive the new throw path) |
+| **Depends on** | **P2-06** (a fetch failure must be detectable), ✅ **P1-04** *(merged — the loop survives the new throw path)* |
 | **Blocks** | — |
-| **Conflict surface** | `src/Kbot.MailService/MonthlyReporter.cs`, `src/Kbot.MailService/Utility/MailSenderService.cs`, `src/Kbot.MailService/DailyReporter.cs` (also P1-04) |
+| **Conflict surface** | `src/Kbot.MailService/MonthlyReporter.cs`, `src/Kbot.MailService/Utility/MailSenderService.cs`, `src/Kbot.MailService/DailyReporter.cs` (P1-04's guards are already merged there) |
 
 ## Problem
 

--- a/src/Kbot.Common/Helpers/ExponentialBackoff.cs
+++ b/src/Kbot.Common/Helpers/ExponentialBackoff.cs
@@ -1,0 +1,79 @@
+namespace Kbot.Common.Helpers;
+
+/// <summary>
+/// Retry pacing for the worker loops: the delay doubles with every consecutive failure, is jittered,
+/// and never leaves the <c>[baseDelay, maxDelay]</c> range. <see cref="Reset"/> puts it back to
+/// <c>baseDelay</c> after a successful iteration.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The jitter window for attempt <c>n</c> is the span between the previous ceiling and the current
+/// one — <c>base·2^(n-1) … base·2^n</c>, capped at <c>maxDelay</c>. That de-correlates retries
+/// without ever returning a delay shorter than the one before it, which is what lets a caller state
+/// that it backs off monotonically. Once the ceiling reaches <c>maxDelay</c> every further attempt
+/// returns exactly <c>maxDelay</c>.
+/// </para>
+/// <para>
+/// Not thread-safe by design: one instance belongs to one loop. <see cref="Random.Shared"/> is used
+/// for the jitter, so there is no shared <see cref="Random"/> instance to synchronise.
+/// </para>
+/// </remarks>
+public sealed class ExponentialBackoff
+{
+  /// <summary>
+  /// Doubling stops here. Any sane cap is reached long before, and it keeps <c>2^n</c> finite.
+  /// </summary>
+  private const int MaxAttempt = 30;
+
+  private readonly TimeSpan _baseDelay;
+  private readonly TimeSpan _maxDelay;
+  private int _attempt;
+
+  /// <param name="baseDelay">
+  /// The first delay and the floor of every later one. A negative value is treated as zero.
+  /// </param>
+  /// <param name="maxDelay">
+  /// The cap. A value below <paramref name="baseDelay"/> is raised to it, so the range is never
+  /// inverted.
+  /// </param>
+  public ExponentialBackoff(TimeSpan baseDelay, TimeSpan maxDelay)
+  {
+    _baseDelay = baseDelay < TimeSpan.Zero ? TimeSpan.Zero : baseDelay;
+    _maxDelay = maxDelay < _baseDelay ? _baseDelay : maxDelay;
+  }
+
+  /// <summary>
+  /// The delay to wait before the next attempt, and counts the attempt.
+  /// </summary>
+  public TimeSpan Next()
+  {
+    var ceiling = CeilingFor(_attempt);
+    var floor = _attempt == 0 ? ceiling : CeilingFor(_attempt - 1);
+    if (_attempt < MaxAttempt)
+    {
+      _attempt++;
+    }
+
+    if (ceiling <= floor)
+    {
+      return ceiling;
+    }
+    var jitter = (long)(Random.Shared.NextDouble() * (ceiling - floor).Ticks);
+    return floor + TimeSpan.FromTicks(jitter);
+  }
+
+  /// <summary>
+  /// Forgets the failure history, so the next <see cref="Next"/> returns the base delay again.
+  /// </summary>
+  public void Reset() => _attempt = 0;
+
+  /// <summary>
+  /// <c>baseDelay·2^attempt</c>, capped. Computed in <see cref="double"/> so a large base delay
+  /// cannot overflow the tick arithmetic on the way to the cap.
+  /// </summary>
+  private TimeSpan CeilingFor(int attempt)
+  {
+    var scaledTicks = _baseDelay.Ticks * Math.Pow(2, Math.Min(attempt, MaxAttempt));
+    return scaledTicks >= _maxDelay.Ticks ? _maxDelay : TimeSpan.FromTicks((long)scaledTicks);
+  }
+}

--- a/src/Kbot.DcaService/DcaWorker.cs
+++ b/src/Kbot.DcaService/DcaWorker.cs
@@ -1,6 +1,7 @@
 using Kbot.Common.Api;
 using Kbot.Common.Dtos;
 using Kbot.Common.Enums;
+using Kbot.Common.Helpers;
 using Kbot.Common.Options;
 using Kbot.DcaService.Models;
 using Kbot.DcaService.Options;
@@ -36,6 +37,12 @@ public class DcaWorker(
 
   public string? FixOrderId { get; set; }
 
+  /// <summary>
+  /// The shortest pause after a failed cycle, used only when <see cref="WaitOptions"/> yields a
+  /// non-positive backoff delay.
+  /// </summary>
+  private static readonly TimeSpan MinimumFailureDelay = TimeSpan.FromSeconds(1);
+
   protected override async Task ExecuteAsync(CancellationToken stoppingToken)
   {
     logger.LogInformation("DCA Worker running at: {time}", DateTime.UtcNow);
@@ -56,6 +63,71 @@ public class DcaWorker(
       );
     }
 
+    // The guard below is the last line of defence for the whole service: an exception that escapes
+    // a BackgroundService stops the host (BackgroundServiceExceptionBehavior.StopHost), Docker's
+    // `restart: unless-stopped` starts the container again, and a restart that reloads pre-order
+    // state is an opportunity for an unscheduled buy. Faults are logged and paced here instead.
+    var backoff = new ExponentialBackoff(
+      waitOptions.Value.MinWaitTime,
+      waitOptions.Value.MaxWaitTime
+    );
+    var isStateSeeded = false;
+
+    while (!stoppingToken.IsCancellationRequested)
+    {
+      TimeSpan waitTime;
+      try
+      {
+        if (!isStateSeeded)
+        {
+          SeedState();
+          isStateSeeded = true;
+        }
+
+        waitTime = await InvestmentCycle(stoppingToken);
+
+        State.Save();
+        backoff.Reset();
+
+        waitTime = ClampToWaitBounds(waitTime);
+      }
+      catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+      {
+        break;
+      }
+      catch (Exception ex)
+      {
+        waitTime = backoff.Next();
+        // Never a non-positive delay: a WaitOptions of 00:00:00 passes validation today, and that
+        // would turn a persistent fault into a busy loop against Kraken. Rejecting such a
+        // configuration outright is P1-07.
+        if (waitTime <= TimeSpan.Zero)
+        {
+          waitTime = MinimumFailureDelay;
+        }
+        logger.LogError(ex, "Investment cycle failed; retrying in {RetryIn}.", waitTime);
+      }
+
+      logger.LogInformation("Waiting for {waitTime}", waitTime);
+      try
+      {
+        await Task.Delay(waitTime, stoppingToken);
+      }
+      catch (OperationCanceledException)
+      {
+        break;
+      }
+    }
+  }
+
+  /// <summary>
+  /// Loads the persisted state and seeds the top-up window. Called from inside the loop's guard
+  /// because every step can throw — a missing state directory, a top-up day that is not a valid day
+  /// of the month, an empty holiday cache — and before the loop existed such a throw stopped the
+  /// host outright. Retried on the next iteration after a backoff delay.
+  /// </summary>
+  private void SeedState()
+  {
     State = DcaStateHandler.Load();
     var nextTopUpTime = computeService.ComputeNextTopUpTime(
       DateTime.UtcNow,
@@ -68,21 +140,12 @@ public class DcaWorker(
       State,
       balanceOptions.Value.DefaultTopupDayOfMonth
     );
+  }
 
-    while (!stoppingToken.IsCancellationRequested)
-    {
-      var waitTime = await InvestmentCycle(stoppingToken);
-
-      State.Save();
-
-      waitTime =
-        waitTime > waitOptions.Value.MaxWaitTime ? waitOptions.Value.MaxWaitTime : waitTime;
-      waitTime =
-        waitTime < waitOptions.Value.MinWaitTime ? waitOptions.Value.MinWaitTime : waitTime;
-
-      logger.LogInformation("Waiting for {waitTime}", waitTime);
-      await Task.Delay(waitTime, stoppingToken);
-    }
+  private TimeSpan ClampToWaitBounds(TimeSpan waitTime)
+  {
+    waitTime = waitTime > waitOptions.Value.MaxWaitTime ? waitOptions.Value.MaxWaitTime : waitTime;
+    return waitTime < waitOptions.Value.MinWaitTime ? waitOptions.Value.MinWaitTime : waitTime;
   }
 
   internal async Task<TimeSpan> InvestmentCycle(CancellationToken stoppingToken)

--- a/src/Kbot.MailService/DailyReporter.cs
+++ b/src/Kbot.MailService/DailyReporter.cs
@@ -1,3 +1,4 @@
+using Kbot.Common.Helpers;
 using Kbot.MailService.Options;
 using Kbot.MailService.Utility;
 using Microsoft.Extensions.Options;
@@ -11,12 +12,20 @@ public class DailyReporter(
   IOptions<MailOptions> mailOptions
 ) : BackgroundService
 {
+  // A failed reporting round is retried on this schedule instead of escalating: MailSenderService
+  // deliberately rethrows, and an unguarded rethrow out of a BackgroundService stops the host, which
+  // Docker then restarts — so a transient Gmail outage used to become a restart loop.
+  private static readonly TimeSpan RetryBaseDelay = TimeSpan.FromMinutes(1);
+  private static readonly TimeSpan RetryMaxDelay = TimeSpan.FromHours(1);
+
+  private readonly RestartNoticeThrottle _restartNotice = new(logger);
+
   protected override async Task ExecuteAsync(CancellationToken stoppingToken)
   {
     logger.LogInformation("Worker running at: {time}", DateTimeOffset.UtcNow);
-    await mailSender.WelcomeOrRestartMessage();
-    logger.LogInformation("Send Mail as startup to verify the service is running and works.");
-    await monthlyReporter.SendReportOnStartup();
+    await SendStartupMails();
+
+    var backoff = new ExponentialBackoff(RetryBaseDelay, RetryMaxDelay);
     while (!stoppingToken.IsCancellationRequested)
     {
       var now = DateTime.UtcNow;
@@ -31,12 +40,62 @@ public class DailyReporter(
       if (now >= nextRunTime)
         nextRunTime = nextRunTime.AddDays(1);
 
-      var delay = nextRunTime - now;
       logger.LogInformation("Next run time: {time}", nextRunTime);
-      await Task.Delay(delay, stoppingToken);
+      if (!await DelayAsync(nextRunTime - now, stoppingToken))
+        break;
 
-      await SendDailyMail();
-      await monthlyReporter.SendReportAsync();
+      try
+      {
+        await SendDailyMail();
+        await monthlyReporter.SendReportAsync();
+        backoff.Reset();
+      }
+      catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+      {
+        break;
+      }
+      catch (Exception ex)
+      {
+        var retryIn = backoff.Next();
+        logger.LogError(
+          ex,
+          "The daily reporting round failed; the next attempt is delayed by {RetryIn}.",
+          retryIn
+        );
+        if (!await DelayAsync(retryIn, stoppingToken))
+          break;
+      }
+    }
+  }
+
+  /// <summary>
+  /// The two startup mails, each guarded on its own: a failed startup mail must not keep the daily
+  /// loop from running, and it must not take the host down either.
+  /// </summary>
+  private async Task SendStartupMails()
+  {
+    try
+    {
+      var utcNow = DateTimeOffset.UtcNow;
+      if (_restartNotice.ShouldSend(utcNow))
+      {
+        await mailSender.WelcomeOrRestartMessage();
+        _restartNotice.RecordSent(utcNow);
+        logger.LogInformation("Send Mail as startup to verify the service is running and works.");
+      }
+    }
+    catch (Exception ex)
+    {
+      logger.LogError(ex, "The startup notification failed; continuing with the daily loop.");
+    }
+
+    try
+    {
+      await monthlyReporter.SendReportOnStartup();
+    }
+    catch (Exception ex)
+    {
+      logger.LogError(ex, "The startup report failed; continuing with the daily loop.");
     }
   }
 
@@ -50,6 +109,27 @@ public class DailyReporter(
     catch (Exception e)
     {
       logger.LogError(e, "An error occurred while sending daily mail.");
+    }
+  }
+
+  /// <summary>
+  /// Waits, and reports whether the wait completed rather than the service being stopped. A stop is
+  /// not an error: it must exit the loop without a logged exception.
+  /// </summary>
+  private static async Task<bool> DelayAsync(TimeSpan delay, CancellationToken stoppingToken)
+  {
+    if (delay <= TimeSpan.Zero)
+    {
+      return !stoppingToken.IsCancellationRequested;
+    }
+    try
+    {
+      await Task.Delay(delay, stoppingToken);
+      return true;
+    }
+    catch (OperationCanceledException)
+    {
+      return false;
     }
   }
 }

--- a/src/Kbot.MailService/Utility/RestartNoticeThrottle.cs
+++ b/src/Kbot.MailService/Utility/RestartNoticeThrottle.cs
@@ -1,0 +1,106 @@
+using System.Text.Json;
+
+namespace Kbot.MailService.Utility;
+
+/// <summary>
+/// Rate-limits the startup notification mail (<c>"DCA - Welcome"</c> / <c>"DCA - Restart of
+/// Container"</c>) so a container that keeps restarting cannot keep mailing.
+/// </summary>
+/// <remarks>
+/// The timestamp of the last successful send is kept in its own small file next to the other state
+/// files, which is what makes the limit survive the restart it is meant to catch. A missing,
+/// unreadable or future-dated marker counts as "no recent send": the notification is worth one mail
+/// too many far more than it is worth being silently switched off.
+/// </remarks>
+public sealed class RestartNoticeThrottle(
+  ILogger logger,
+  string? markerPath = null,
+  TimeSpan? minimumInterval = null
+)
+{
+  /// <summary>Long enough that a Docker restart loop sends at most one mail per hour.</summary>
+  public static readonly TimeSpan DefaultMinimumInterval = TimeSpan.FromHours(1);
+
+  private const string DefaultMarkerPath = "state/restart-notice.json";
+  private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+  private readonly string _markerPath = markerPath ?? DefaultMarkerPath;
+  private readonly TimeSpan _minimumInterval = minimumInterval ?? DefaultMinimumInterval;
+
+  /// <summary>
+  /// Whether the startup notification may be sent now.
+  /// </summary>
+  public bool ShouldSend(DateTimeOffset utcNow)
+  {
+    var lastSent = ReadLastSent();
+    if (lastSent is null)
+    {
+      return true;
+    }
+
+    var elapsed = utcNow - lastSent.Value;
+    if (elapsed >= _minimumInterval || elapsed < TimeSpan.Zero)
+    {
+      return true;
+    }
+
+    logger.LogWarning(
+      "Startup notification suppressed: the last one was sent {Elapsed} ago, which is less than "
+        + "{MinimumInterval}. A restarting container must not keep mailing.",
+      elapsed,
+      _minimumInterval
+    );
+    return false;
+  }
+
+  /// <summary>
+  /// Records a successful send. Called only after the mail actually went out, so a failed send does
+  /// not start the quiet period.
+  /// </summary>
+  public void RecordSent(DateTimeOffset utcNow)
+  {
+    try
+    {
+      var directory = Path.GetDirectoryName(_markerPath);
+      if (!string.IsNullOrEmpty(directory))
+      {
+        Directory.CreateDirectory(directory);
+      }
+      File.WriteAllText(_markerPath, JsonSerializer.Serialize(new Marker(utcNow), JsonOptions));
+    }
+    catch (Exception ex)
+    {
+      // Losing the marker only costs the rate limit, so it must never take the service down with
+      // it. Unifying the state-file IO is P4-01.
+      logger.LogWarning(
+        ex,
+        "Could not record the startup notification in {MarkerPath}.",
+        _markerPath
+      );
+    }
+  }
+
+  private DateTimeOffset? ReadLastSent()
+  {
+    try
+    {
+      if (!File.Exists(_markerPath))
+      {
+        return null;
+      }
+      var marker = JsonSerializer.Deserialize<Marker>(File.ReadAllText(_markerPath), JsonOptions);
+      return marker?.LastSentUtc;
+    }
+    catch (Exception ex)
+    {
+      logger.LogWarning(
+        ex,
+        "Could not read the startup notification marker {MarkerPath}; treating it as absent.",
+        _markerPath
+      );
+      return null;
+    }
+  }
+
+  private sealed record Marker(DateTimeOffset LastSentUtc);
+}

--- a/test/Kbot.Common.Test/ExponentialBackoffTest.cs
+++ b/test/Kbot.Common.Test/ExponentialBackoffTest.cs
@@ -1,0 +1,116 @@
+using Kbot.Common.Helpers;
+
+namespace Kbot.Common.Test;
+
+/// <summary>
+/// The pacing the worker loops rely on: a first delay of exactly the base, delays that never shrink
+/// while failures continue, a hard cap, and a reset back to the base after a success.
+/// </summary>
+[TestClass]
+public class ExponentialBackoffTest
+{
+  private static readonly TimeSpan Base = TimeSpan.FromSeconds(10);
+  private static readonly TimeSpan Max = TimeSpan.FromMinutes(4); // Base * 2^4 * 1.5
+
+  [TestMethod]
+  public void Next_StartsAtTheBaseDelay()
+  {
+    var backoff = new ExponentialBackoff(Base, Max);
+
+    Assert.AreEqual(Base, backoff.Next());
+  }
+
+  [TestMethod]
+  public void Next_NeverShrinksAndNeverExceedsTheCap()
+  {
+    var backoff = new ExponentialBackoff(Base, Max);
+    var previous = TimeSpan.Zero;
+
+    for (var attempt = 0; attempt < 100; attempt++)
+    {
+      var delay = backoff.Next();
+
+      Assert.IsTrue(
+        delay >= previous,
+        $"Attempt {attempt} returned {delay}, which is shorter than the previous {previous}."
+      );
+      Assert.IsTrue(delay >= Base, $"Attempt {attempt} returned {delay}, below the base {Base}.");
+      Assert.IsTrue(delay <= Max, $"Attempt {attempt} returned {delay}, above the cap {Max}.");
+      previous = delay;
+    }
+
+    Assert.AreEqual(Max, previous, "A long run of failures must settle on the cap.");
+  }
+
+  [TestMethod]
+  public void Next_DoublesTheWindowUntilItReachesTheCap()
+  {
+    var backoff = new ExponentialBackoff(Base, Max);
+
+    backoff.Next(); // attempt 0: exactly Base.
+    var second = backoff.Next();
+    var third = backoff.Next();
+
+    Assert.IsTrue(second >= Base && second <= 2 * Base, $"Second delay {second} left its window.");
+    Assert.IsTrue(third >= 2 * Base && third <= 4 * Base, $"Third delay {third} left its window.");
+  }
+
+  [TestMethod]
+  public void Next_JittersInsideTheWindow()
+  {
+    // Full jitter would let a delay come out shorter than the previous one, which the worker loops
+    // must not do; the jitter therefore fills the window between the previous ceiling and the
+    // current one. Two samples of the same attempt should still differ.
+    var samples = new List<TimeSpan>();
+    for (var run = 0; run < 50; run++)
+    {
+      var backoff = new ExponentialBackoff(Base, Max);
+      backoff.Next();
+      backoff.Next();
+      samples.Add(backoff.Next());
+    }
+
+    Assert.IsGreaterThan(1, samples.Distinct().Count(), "The delay is not jittered at all.");
+    Assert.IsTrue(samples.All(s => s >= 2 * Base && s <= 4 * Base));
+  }
+
+  [TestMethod]
+  public void Reset_ReturnsToTheBaseDelay()
+  {
+    var backoff = new ExponentialBackoff(Base, Max);
+    for (var attempt = 0; attempt < 5; attempt++)
+    {
+      backoff.Next();
+    }
+
+    backoff.Reset();
+
+    Assert.AreEqual(Base, backoff.Next(), "A successful cycle must clear the failure history.");
+  }
+
+  [TestMethod]
+  public void Constructor_NormalisesADegenerateRange()
+  {
+    // WaitOptions currently accepts 00:00:00 and does not require Min <= Max at every call site, so
+    // neither a negative base nor an inverted range may produce a nonsense delay. Rejecting such a
+    // configuration outright is P1-07.
+    var negative = new ExponentialBackoff(TimeSpan.FromSeconds(-5), Max);
+    var inverted = new ExponentialBackoff(Base, TimeSpan.Zero);
+
+    Assert.AreEqual(TimeSpan.Zero, negative.Next());
+    Assert.AreEqual(Base, inverted.Next());
+    Assert.AreEqual(Base, inverted.Next(), "An inverted range collapses onto the base delay.");
+  }
+
+  [TestMethod]
+  public void Next_DoesNotOverflowOnAHugeBaseDelay()
+  {
+    var backoff = new ExponentialBackoff(TimeSpan.FromDays(1000), TimeSpan.MaxValue);
+
+    for (var attempt = 0; attempt < 100; attempt++)
+    {
+      var delay = backoff.Next();
+      Assert.IsTrue(delay > TimeSpan.Zero, $"Attempt {attempt} overflowed into {delay}.");
+    }
+  }
+}

--- a/test/Kbot.DcaService.Test/WorkerLoopResilienceTest.cs
+++ b/test/Kbot.DcaService.Test/WorkerLoopResilienceTest.cs
@@ -1,0 +1,229 @@
+using System.Diagnostics;
+using Kbot.Common.Api;
+using Kbot.Common.Enums;
+using Kbot.Common.Helpers;
+using Kbot.Common.Options;
+using Kbot.DcaService.Options;
+using Kbot.DcaService.Utility;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using MsOptions = Microsoft.Extensions.Options.Options;
+
+namespace Kbot.DcaService.Test;
+
+/// <summary>
+/// The worker loop against a collaborator that throws on every iteration (C-5). A
+/// <see cref="BackgroundService"/> that lets an exception escape stops the host, Docker restarts the
+/// container and the reloaded pre-order state can buy again — so the loop has to log the fault, pace
+/// the retry and stay alive. No network, no credentials, no order.
+/// </summary>
+[TestClass]
+public class WorkerLoopResilienceTest
+{
+  [TestMethod]
+  public async Task ExecuteAsync_LogsBacksOffAndStaysUpWhenEveryIterationThrows()
+  {
+    var minWait = TimeSpan.FromMilliseconds(20);
+    var maxWait = TimeSpan.FromMilliseconds(160);
+    var (worker, log) = NewWorker(minWait, maxWait);
+
+    await worker.StartAsync(CancellationToken.None);
+    try
+    {
+      await WaitUntil(() => log.Errors.Count >= 8, TimeSpan.FromSeconds(20));
+
+      Assert.IsNotNull(worker.ExecuteTask);
+      Assert.IsFalse(
+        worker.ExecuteTask.IsCompleted,
+        "A failing cycle must not end the worker: that is what stops the host."
+      );
+
+      var errors = log.Errors;
+      Assert.IsTrue(
+        errors.All(e => e.Exception is not null),
+        "Every caught exception has to reach the sink as an exception, not as a message."
+      );
+      Assert.IsTrue(
+        errors.All(e => e.Message.Contains("Investment cycle failed")),
+        $"Unexpected errors logged: {string.Join(" | ", errors.Select(e => e.Message))}"
+      );
+
+      var delays = errors.Select(e => e.RetryIn).ToList();
+      Assert.IsTrue(
+        delays.All(d => d is not null),
+        "The retry delay belongs in the log line, so an operator can see the backoff."
+      );
+      var waits = delays.Select(d => d!.Value).ToList();
+      Assert.AreEqual(minWait, waits[0], "The first retry waits exactly MinWaitTime.");
+      for (var i = 1; i < waits.Count; i++)
+      {
+        Assert.IsTrue(
+          waits[i] >= waits[i - 1],
+          $"Retry {i} waited {waits[i]}, less than the previous {waits[i - 1]}."
+        );
+      }
+      Assert.IsTrue(
+        waits.All(w => w >= minWait && w <= maxWait),
+        $"Every retry delay must stay within [{minWait}, {maxWait}]: {string.Join(", ", waits)}"
+      );
+      Assert.AreEqual(maxWait, waits[^1], "A run of failures has to settle on MaxWaitTime.");
+    }
+    finally
+    {
+      await worker.StopAsync(CancellationToken.None);
+    }
+  }
+
+  [TestMethod]
+  public async Task ExecuteAsync_StoppingExitsPromptlyAndIsNotAnError()
+  {
+    // Long enough that the worker is certainly sitting in its retry delay when the stop arrives.
+    var wait = TimeSpan.FromSeconds(30);
+    var (worker, log) = NewWorker(wait, wait);
+
+    await worker.StartAsync(CancellationToken.None);
+    await WaitUntil(() => log.Errors.Count >= 1, TimeSpan.FromSeconds(20));
+    var errorsBeforeStop = log.Errors.Count;
+
+    var stopwatch = Stopwatch.StartNew();
+    await worker.StopAsync(CancellationToken.None);
+    stopwatch.Stop();
+
+    Assert.IsLessThan(
+      TimeSpan.FromSeconds(5),
+      stopwatch.Elapsed,
+      "Cancellation must break the loop instead of waiting the retry delay out."
+    );
+    Assert.AreEqual(
+      TaskStatus.RanToCompletion,
+      worker.ExecuteTask!.Status,
+      "A stop is an orderly exit, not a fault."
+    );
+    Assert.AreEqual(errorsBeforeStop, log.Errors.Count, "Stopping the service is not an error.");
+  }
+
+  /// <summary>
+  /// A worker whose first act throws: <see cref="HolidayService.IsHoliday"/> takes the minimum of an
+  /// empty cache, so seeding the top-up window raises <see cref="InvalidOperationException"/> on
+  /// every iteration (H-7, owned by P4-02 — this test only needs a reliable thrower). The transport
+  /// is never reached.
+  /// </summary>
+  private static (DcaWorker Worker, RecordingLogger Log) NewWorker(
+    TimeSpan minWaitTime,
+    TimeSpan maxWaitTime
+  )
+  {
+    var cultureOptions = MsOptions.Create(
+      new CultureOptions
+      {
+        CultureString = "de-CH",
+        CountyCode = "CH-ZH",
+        Fiat = "CHF",
+      }
+    );
+    var log = new RecordingLogger();
+    var api = new KrakenApi(
+      NullLogger<KrakenApi>.Instance,
+      MsOptions.Create(new Secrets { ApiKey = "test-api-key", ApiSecret = "dGVzdC1zZWNyZXQ=" }),
+      new UnreachableTransport()
+    );
+    var worker = new DcaWorker(
+      log,
+      new TimeComputeService(
+        NullLogger<TimeComputeService>.Instance,
+        new HolidayService(NullLogger<HolidayService>.Instance, cultureOptions)
+      ),
+      new KrakenClient(NullLogger<KrakenClient>.Instance, api),
+      MsOptions.Create(
+        new OrderOptions
+        {
+          Type = OrderType.Limit,
+          Fee = 0.4,
+          MinOrderVolume = 0.00005,
+          AskMultiplier = 1.0,
+          CryptoPair = "XBTCHF",
+        }
+      ),
+      MsOptions.Create(new BalanceOptions { DefaultTopupDayOfMonth = 26, ReserveFiat = 100 }),
+      cultureOptions,
+      MsOptions.Create(new WaitOptions { MinWaitTime = minWaitTime, MaxWaitTime = maxWaitTime })
+    );
+    return (worker, log);
+  }
+
+  private static async Task WaitUntil(Func<bool> condition, TimeSpan timeout)
+  {
+    var deadline = DateTime.UtcNow + timeout;
+    while (!condition())
+    {
+      if (DateTime.UtcNow > deadline)
+      {
+        Assert.Fail($"The expected worker activity did not happen within {timeout}.");
+      }
+      await Task.Delay(10);
+    }
+  }
+
+  private sealed class UnreachableTransport : HttpMessageHandler
+  {
+    protected override Task<HttpResponseMessage> SendAsync(
+      HttpRequestMessage request,
+      CancellationToken cancellationToken
+    ) => throw new InvalidOperationException($"No request expected, got {request.RequestUri}.");
+  }
+
+  /// <summary>
+  /// Keeps every error the worker logged, together with its exception and the structured
+  /// <c>RetryIn</c> value, so the backoff can be asserted without measuring wall-clock time.
+  /// </summary>
+  private sealed class RecordingLogger : ILogger<DcaWorker>
+  {
+    private readonly List<LoggedError> _errors = [];
+    private readonly Lock _gate = new();
+
+    internal List<LoggedError> Errors
+    {
+      get
+      {
+        lock (_gate)
+        {
+          return [.. _errors];
+        }
+      }
+    }
+
+    public IDisposable? BeginScope<TState>(TState state)
+      where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+      LogLevel logLevel,
+      EventId eventId,
+      TState state,
+      Exception? exception,
+      Func<TState, Exception?, string> formatter
+    )
+    {
+      if (logLevel < LogLevel.Error)
+      {
+        return;
+      }
+      TimeSpan? retryIn = null;
+      if (state is IReadOnlyList<KeyValuePair<string, object?>> values)
+      {
+        var retry = values.FirstOrDefault(v => v.Key == "RetryIn").Value;
+        if (retry is TimeSpan span)
+        {
+          retryIn = span;
+        }
+      }
+      lock (_gate)
+      {
+        _errors.Add(new LoggedError(formatter(state, exception), exception, retryIn));
+      }
+    }
+  }
+
+  private sealed record LoggedError(string Message, Exception? Exception, TimeSpan? RetryIn);
+}

--- a/test/Kbot.MailService.Test/RestartNoticeThrottleTest.cs
+++ b/test/Kbot.MailService.Test/RestartNoticeThrottleTest.cs
@@ -1,0 +1,101 @@
+using Kbot.MailService.Utility;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Kbot.MailService.Test;
+
+/// <summary>
+/// The rate limit on the startup notification. Without it, a host that keeps dying and being
+/// restarted by Docker mails "DCA - Restart of Container" on every attempt.
+/// </summary>
+[TestClass]
+public class RestartNoticeThrottleTest
+{
+  private static readonly TimeSpan Interval = TimeSpan.FromHours(1);
+  private static readonly DateTimeOffset Now = new(2026, 8, 22, 12, 0, 0, TimeSpan.Zero);
+
+  private string _markerPath = null!;
+
+  [TestInitialize]
+  public void Setup() =>
+    _markerPath = Path.Combine(
+      Path.GetTempPath(),
+      $"kbot-restart-notice-{Guid.NewGuid():N}",
+      "restart-notice.json"
+    );
+
+  [TestCleanup]
+  public void Cleanup()
+  {
+    var directory = Path.GetDirectoryName(_markerPath)!;
+    if (Directory.Exists(directory))
+    {
+      Directory.Delete(directory, recursive: true);
+    }
+  }
+
+  [TestMethod]
+  public void ShouldSend_IsTrueOnAFirstRun()
+  {
+    Assert.IsTrue(NewThrottle().ShouldSend(Now), "A first start has to introduce itself.");
+  }
+
+  [TestMethod]
+  public void ShouldSend_IsFalseWithinTheQuietPeriod()
+  {
+    var throttle = NewThrottle();
+    throttle.RecordSent(Now);
+
+    Assert.IsFalse(
+      NewThrottle().ShouldSend(Now.AddMinutes(1)),
+      "A restart a minute after the last notification must stay silent."
+    );
+  }
+
+  [TestMethod]
+  public void ShouldSend_IsTrueOnceTheQuietPeriodPassed()
+  {
+    NewThrottle().RecordSent(Now);
+
+    Assert.IsTrue(NewThrottle().ShouldSend(Now + Interval));
+  }
+
+  [TestMethod]
+  public void ShouldSend_IsTrueWhenTheMarkerLiesInTheFuture()
+  {
+    // A clock correction must not silence the notification for good.
+    NewThrottle().RecordSent(Now.AddDays(30));
+
+    Assert.IsTrue(NewThrottle().ShouldSend(Now));
+  }
+
+  [TestMethod]
+  public void ShouldSend_IsTrueWhenTheMarkerIsUnreadable()
+  {
+    Directory.CreateDirectory(Path.GetDirectoryName(_markerPath)!);
+    File.WriteAllText(_markerPath, "not json");
+
+    Assert.IsTrue(
+      NewThrottle().ShouldSend(Now),
+      "A corrupt marker must not switch the notification off."
+    );
+  }
+
+  [TestMethod]
+  public void RecordSent_SurvivesAnUnwritableLocation()
+  {
+    // The rate limit is a convenience; losing it may never take the service down.
+    var throttle = new RestartNoticeThrottle(
+      NullLogger.Instance,
+      Path.Combine(_markerPath, "nested", "marker.json"),
+      Interval
+    );
+    Directory.CreateDirectory(Path.GetDirectoryName(_markerPath)!);
+    File.WriteAllText(_markerPath, "a file where a directory would have to be");
+
+    throttle.RecordSent(Now);
+
+    Assert.IsTrue(throttle.ShouldSend(Now));
+  }
+
+  private RestartNoticeThrottle NewThrottle() => new(NullLogger.Instance, _markerPath, Interval);
+}


### PR DESCRIPTION
Implements [docs/plans/p1-04-c5-worker-loop-resilience.md](docs/plans/p1-04-c5-worker-loop-resilience.md).

Closes **C-5** — *neither worker loop has any exception handling*. Every throw in this codebase used
to escape its `BackgroundService`, stop the host (`BackgroundServiceExceptionBehavior.StopHost`) and
let `restart: unless-stopped` restart the container with pre-order state, which is an opportunity for
an unscheduled buy. The individual throws are untouched; the loops now survive them.

> **Rebased onto #45 (P1-03) and #44 (P1-08).** The planned `DcaWorker.cs` order P1-02 → P1-03 → P1-04 is satisfied:
> P1-03's post-order `State.Save()` and its comment are intact, and the guard wraps them rather than
> replacing them. GitHub reports the PR mergeable.

## What changed

- **`src/Kbot.Common/Helpers/ExponentialBackoff.cs`** (new) — shared retry pacing. `Next()` doubles
  the delay per consecutive failure, `Reset()` returns it to the base after a success, every value
  stays inside `[baseDelay, maxDelay]`, and the jitter comes from `Random.Shared`.
- **`src/Kbot.DcaService/DcaWorker.cs`** — the loop body is guarded. A fault is logged with
  `LogError(ex, …)` plus the retry delay and paced by a backoff floored at `WaitOptions.MinWaitTime`
  and capped at `WaitOptions.MaxWaitTime`; a successful cycle resets it. The startup path
  (`DcaStateHandler.Load()` and the first `ComputeNextTopUpTime`) moved into `SeedState()` and runs
  inside the same guard on the first iteration, so a throw there is retried instead of stopping the
  host before the loop exists. `Task.Delay` is guarded too, so a stop exits without logging an error.
- **`src/Kbot.MailService/DailyReporter.cs`** — `WelcomeOrRestartMessage()` and
  `SendReportOnStartup()` are guarded individually (a failed startup mail no longer prevents the
  daily loop from running), and the per-iteration `SendDailyMail()` / `SendReportAsync()` pair is
  guarded with its own backoff, 1 min → 1 h.
- **`src/Kbot.MailService/Utility/RestartNoticeThrottle.cs`** (new) — the restart notification is
  rate-limited to one an hour, so a container restart loop cannot flood the inbox.

## Two decisions worth reviewing

**The jitter is not "full jitter".** The plan asked for full jitter, but full jitter draws from
`[0, ceiling]` and can return a delay *shorter* than the previous one, which contradicts the
acceptance criterion "monotonically increasing delays capped at `MaxWaitTime`". The jitter therefore
fills the window between the previous ceiling and the current one (`base·2^(n-1) … base·2^n`, capped)
— still de-correlated, but never shrinking. Documented in the class remarks and pinned by a test.

**How the restart mail is rate-limited** (the plan asked me to pick the simplest correct option and
say which): a marker file `state/restart-notice.json` holding the timestamp of the last *successful*
send, next to the other state files. The "process has been up < 1 min" alternative cannot work — a
fresh process cannot tell a crash from a deliberate restart, and anything in memory dies with the
restart the limit is supposed to catch. A second notice within an hour is suppressed; a missing,
unreadable or future-dated marker counts as "no recent send" (the notification is worth one mail too
many more than it is worth being silently switched off), and a marker that cannot be written is a
warning, never a fault.

Also, not spelled out by the plan: a non-positive backoff delay in `DcaWorker` falls back to one
second. `WaitOptions` of `00:00:00` passes validation today (**P1-07** owns that), and pacing a
persistent fault at zero would swap a restart loop for a busy loop against Kraken.

## Verified (on the rebased tree)

- `dotnet build Kbot.sln -warnaserror` — clean, 0 warnings.
- `dotnet test Kbot.sln` — **64 tests pass** under the default (safe) filter, 0 failed.
  `KBOT_ALLOW_LIVE_TRADING` was never set; no live test ran, no order was placed.
- `csharpier check .` — clean, 81 files.

New tests:

- `test/Kbot.Common.Test/ExponentialBackoffTest.cs` — first delay, monotonic growth, the cap, the
  jitter window, `Reset()`, degenerate ranges, no overflow.
- `test/Kbot.DcaService.Test/WorkerLoopResilienceTest.cs` — drives the real `ExecuteAsync` against a
  collaborator that throws on every iteration (an empty `HolidayService` cache) and asserts one
  logged error *with its exception* per iteration, retry delays that never shrink and settle on
  `MaxWaitTime`, and a worker task that is still running. A second test asserts that stopping the
  service exits promptly, runs to completion and logs nothing. Hermetic — no network, no credentials.
- `test/Kbot.MailService.Test/RestartNoticeThrottleTest.cs` — quiet period, first run, stale marker,
  future-dated marker, corrupt marker, unwritable location.

## Deliberately left out

- The individual throws: C-4 → **P1-03** (merged), H-7 (the empty holiday cache my test exploits) →
  **P4-02**, state-file IO → **P4-01**.
- Watermark semantics on a failed fetch → **P2-07**. `CancellationToken` propagation into the Kraken
  client → **P4-04**. Healthchecks / dead-man's switch → **P4-06** and `FUTURE_FEATURES.md` F-1.
  Options validation (`WaitOptions` of `00:00:00`) → **P1-07**.
- No test drives `DailyReporter.ExecuteAsync`: it depends on the concrete `MailSenderService`, which
  needs a database. Those seams are **P3-01** / **P3-03**. The throttle is covered directly instead.

## Close-out docs

The final `docs:` commit marks C-5 resolved in the plan file, `HANDOFF.md` (§1, §4, §5, §7, §8),
`ROADMAP.md`, `REVIEW.md` and the plan index, and refreshes the cross-plan notes this merge makes
stale — **P2-01's last prerequisite is now met**, and P2-07's `DailyReporter.cs` conflict note now
describes code already on `review-and-fix`. With P1-03 and P1-08 in, the shared status lines read **6 of 64
findings, C-1 … C-5 all closed, Milestone M1 ("safe to run") reached**, and the `DcaWorker.cs` /
`TimeComputeService.cs` merge-order notes are marked settled.

#44 (P1-08) merged first, so its rows were kept as written and mine layered on top: §1 now reads
**6 of 64 findings** with P1-01 (`58c2262`), P1-02 (#43), P1-03 (#45), P1-04 (#46) and P1-08 (#44)
landed, and Wave 0 has P1-06, P1-07, P1-09 and P2-02 left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
