### PR TITLE
fix: P1-07 tighten the options validators (H-10)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -429,12 +429,15 @@ Also send Kraken's `closetime=close` explicitly — the API default is `both`, s
 ### H-10 · Options validators accept degenerate zero values
 
 > ✅ **Resolved** by [P1-07](docs/plans/p1-07-h10-tighten-options-validators.md), merged as PR #47.
-> `MinWaitTime` must now be at least one second and `MaxWaitTime` greater than zero, so the
-> all-zero `WaitOptions` that produced the busy loop no longer starts; `MinOrderVolume` must be
-> greater than zero, `AskMultiplier` sits in `[0.5, 1.5]`, `Fee` in `[0, 100]`, every `double` is
-> checked for finiteness, and `CryptoPair` must look like a pair. `appsettings.json` ships defaults
-> for all four sections, so the only startup failures a checkout without `stack.env` produces are
-> `Secrets` and `CryptoPair` — both deliberate. All of it is unit-tested, which it was not before.
+> `MinWaitTime` must now be at least one second and `MaxWaitTime` between zero and seven days — so
+> the all-zero `WaitOptions` that produced the busy loop no longer starts, and neither does a
+> `MaxWaitTime` that `Task.Delay` would throw on. `MinOrderVolume` must be greater than zero,
+> `AskMultiplier` sits in `[0.5, 1.5]` (and is warned about below 1, where a limit buy can rest
+> unfilled), `Fee` in `[0, 100]`, every `double` is checked for finiteness, and `CryptoPair` must
+> match `^[A-Z0-9]{4,16}$` — the bounds Kraken's live `AssetPairs` list actually needs.
+> `appsettings.json` ships defaults for all four sections, so the only startup failures a checkout
+> without `stack.env` produces are `Secrets` and `CryptoPair` — both deliberate. All of it is
+> unit-tested, which it was not before.
 
 **Files:** [OrderOptions.cs:27-34](src/Kbot.DcaService/Options/OrderOptions.cs#L27-L34) · [WaitOptions.cs:16-23](src/Kbot.DcaService/Options/WaitOptions.cs#L16-L23)
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -428,6 +428,14 @@ Also send Kraken's `closetime=close` explicitly — the API default is `both`, s
 
 ### H-10 · Options validators accept degenerate zero values
 
+> ✅ **Resolved** by [P1-07](docs/plans/p1-07-h10-tighten-options-validators.md), merged as PR #47.
+> `MinWaitTime` must now be at least one second and `MaxWaitTime` greater than zero, so the
+> all-zero `WaitOptions` that produced the busy loop no longer starts; `MinOrderVolume` must be
+> greater than zero, `AskMultiplier` sits in `[0.5, 1.5]`, `Fee` in `[0, 100]`, every `double` is
+> checked for finiteness, and `CryptoPair` must look like a pair. `appsettings.json` ships defaults
+> for all four sections, so the only startup failures a checkout without `stack.env` produces are
+> `Secrets` and `CryptoPair` — both deliberate. All of it is unit-tested, which it was not before.
+
 **Files:** [OrderOptions.cs:27-34](src/Kbot.DcaService/Options/OrderOptions.cs#L27-L34) · [WaitOptions.cs:16-23](src/Kbot.DcaService/Options/WaitOptions.cs#L16-L23)
 
 All numeric checks use `>= 0` rather than `> 0`. Verified by running the built service with no configuration: `Secrets`, `OrderOptions`, `BalanceOptions`, and `CultureOptions` all failed validation — but **`WaitOptions` produced no error at all**, because `MinWaitTime = MaxWaitTime = TimeSpan.Zero` satisfies all three of its rules.
@@ -731,7 +739,7 @@ kept out of the remediation scheduling in [docs/ROADMAP.md](docs/ROADMAP.md).
 | DTO parsers | **None** | `TickerInfoUnparsed.Parse`, `ClosedOrderUnparsed.ToModel`, `OrderParser.ToOrder` — pure functions, ideal targets |
 | Report aggregation | **None** | Exercised, never asserted |
 | HTML / CSV generation | **None** | Including the `NaN` path (M-1) and the culture bug (H-1) |
-| Options validation | **None** | All five validators — which is how H-10 survived |
+| Options validation | ✅ **Covered** *(P1-07)* | `OrderOptions`, `WaitOptions`, `BalanceOptions` and `CultureOptions`, one test per rule, plus the shipped `appsettings.json` defaults. `SecretsValidator` and the two mail validators are still uncovered |
 | `DcaWorker` decision logic | **None (unsafe)** | Runs the real worker against the live exchange and asserts only that a cancel succeeded |
 | DB migration | **None** | Throws on the InMemory provider in every test, swallowed by the retry loop (25 s of the suite's runtime) |
 | Daily/monthly scheduling | **None** | `HourOfDay` UTC-vs-local semantics unverified |

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -14,14 +14,14 @@ then follow §8 to produce the next handoff.
 |---|---|
 | Repo | `dotnet-kraken-dca-bot` — a .NET 10 Kraken DCA bot (6 projects: `Kbot.Common`, `Kbot.DcaService`, `Kbot.MailService` + 3 test projects) |
 | What exists | A full code review ([REVIEW.md](../REVIEW.md)), a phased roadmap ([ROADMAP.md](ROADMAP.md)) and 37 branch-sized implementation plans ([plans/](plans/)) |
-| What has been fixed | **6 of 64 findings.** C-1 (P1-01), C-2 / C-3 (P1-02), C-4 (P1-03), C-5 (P1-04) and H-11 (P1-08) are merged. The rest are open. |
-| Branch state | `main` = upstream, untouched. `review-and-fix` = `main` + the review + these docs, and **the integration branch all work merges into**. P1-01 (`58c2262`), P1-02 (#43), P1-03 (#45), P1-04 (#46) and P1-08 (#44) have landed there; everything else is still open. |
+| What has been fixed | **7 of 64 findings.** C-1 (P1-01), C-2 / C-3 (P1-02), C-4 (P1-03), C-5 (P1-04), H-10 (P1-07) and H-11 (P1-08) are merged. The rest are open. |
+| Branch state | `main` = upstream, untouched. `review-and-fix` = `main` + the review + these docs, and **the integration branch all work merges into**. P1-01 (`58c2262`), P1-02 (#43), P1-03 (#45), P1-04 (#46), P1-07 (#47) and P1-08 (#44) have landed there; everything else is still open. |
 
 **The one thing to know:** the review's verdict is *"not safe to run unattended with real money until
 C-1 … C-5 are fixed."* Those five findings are owned by plans **P1-01, P1-02, P1-03, P1-04**. They are
 all in Wave 0 and they were the point of this handoff. **C-1 … C-5 are all closed, so Milestone M1
-("safe to run") is reached.** What is left in Wave 0 is the non-critical work: P1-06, P1-07, P1-09
-and P2-02.
+("safe to run") is reached.** What is left in Wave 0 is the non-critical work: P1-06, P1-09 and
+P2-02.
 
 ---
 
@@ -70,7 +70,7 @@ If you ever see a plan or an older doc say "base on `main`", it is stale — thi
 | ~~3~~ | ~~[P1-03](plans/p1-03-c4-topup-day-clamp-and-state-order.md)~~ ✅ merged | `fix/p1-c4-topup-day-clamp-and-state-order` | **C-4** | S |
 | ~~4~~ | ~~[P1-04](plans/p1-04-c5-worker-loop-resilience.md)~~ ✅ merged | `fix/p1-c5-worker-loop-resilience` | **C-5** | S |
 | 5 | [P1-06](plans/p1-06-h4-dockerignore-and-secret-copy.md) | `fix/p1-h4-dockerignore-and-secret-copy` | H-4 | S |
-| 6 | [P1-07](plans/p1-07-h10-tighten-options-validators.md) | `fix/p1-h10-tighten-options-validators` | H-10 | S |
+| ~~6~~ | ~~[P1-07](plans/p1-07-h10-tighten-options-validators.md)~~ ✅ merged | `fix/p1-h10-tighten-options-validators` | H-10 | S |
 | ~~7~~ | ~~[P1-08](plans/p1-08-h11-database-credentials-exposure.md)~~ ✅ merged | `fix/p1-h11-database-credentials-exposure` | H-11 | S |
 | 8 | [P1-09](plans/p1-09-m16-redact-secrets-in-logs.md) | `fix/p1-m16-redact-secrets-in-logs` | M-16 | XS |
 | 9 | [P2-02](plans/p2-02-h1-invariant-culture.md) | `fix/p2-h1-invariant-culture` | H-1 | M |
@@ -272,7 +272,7 @@ Rules:
 </details>
 
 <details>
-<summary><b>P1-07 · Tighten the options validators (H-10)</b></summary>
+<summary><b>P1-07 · Tighten the options validators (H-10) — ✅ merged as #47, nothing to do</b></summary>
 
 ```
 Work in the repo dotnet-kraken-dca-bot.
@@ -451,7 +451,7 @@ Every PR updates its own row, on its own branch, before it is opened — see
 | P1-03 | `fix/p1-c4-topup-day-clamp-and-state-order` | ✅ resolved | #45 | via #45 |
 | P1-04 | `fix/p1-c5-worker-loop-resilience` | ✅ resolved | #46 | via #46 |
 | P1-06 | `fix/p1-h4-dockerignore-and-secret-copy` | — | | |
-| P1-07 | `fix/p1-h10-tighten-options-validators` | — | | |
+| P1-07 | `fix/p1-h10-tighten-options-validators` | ✅ resolved | #47 | via #47 |
 | P1-08 | `fix/p1-h11-database-credentials-exposure` | ✅ resolved | #44 | via #44 |
 | P1-09 | `fix/p1-m16-redact-secrets-in-logs` | — | | |
 | P2-02 | `fix/p2-h1-invariant-culture` | — | | |
@@ -471,7 +471,7 @@ Each merge unlocks specific plans. From [ROADMAP.md](ROADMAP.md) §4:
 | ✅ P1-01 *(merged)* | **P1-05** (`ci/p1-h3-build-test-lint-pipeline`) — **now ready**; CI could not be wired up before the tests were safe |
 | ✅ P1-03 *(merged)* | **P1-10** (`test/p1-h12-deterministic-timecompute-tests`) — **now ready**; the clamp it has to assert is in |
 | ✅ P1-02 **and** ✅ P1-04 *(both merged)* | **P2-01** (`refactor/p2-i1-kraken-result-protocol`) — the highest-value change in the review; **now ready** |
-| ✅ P1-03 *(merged)* **and** P1-07 | **P2-08** (`refactor/p2-i5-shared-trading-options`) — now waiting on P1-07 alone |
+| ✅ P1-03 **and** ✅ P1-07 *(both merged)* | **P2-08** (`refactor/p2-i5-shared-trading-options`) — **now ready**; the aligned validators and the top-up clamp it builds on are both in |
 | ✅ P1-08 *(merged)* | **P4-06** (`fix/p4-m17-m21-startup-and-healthchecks`) — **now ready**; the compose file no longer carries the port mapping or the password |
 | P1-05 | **P2-09** (`ci/p2-workflow-hardening`) |
 | P2-02 | **P2-03** (`refactor/p2-h2-decimal-money`) |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -149,7 +149,7 @@ merge order matters (see the note below) but their *development* does not.
 | ~~P1-03~~ ✅ merged | `fix/p1-c4-topup-day-clamp-and-state-order` | C-4 |
 | ~~P1-04~~ ✅ merged | `fix/p1-c5-worker-loop-resilience` | C-5 |
 | P1-06 | `fix/p1-h4-dockerignore-and-secret-copy` | H-4 |
-| P1-07 | `fix/p1-h10-tighten-options-validators` | H-10 |
+| ~~P1-07~~ ✅ merged | `fix/p1-h10-tighten-options-validators` | H-10 |
 | ~~P1-08~~ ✅ merged | `fix/p1-h11-database-credentials-exposure` | H-11 |
 | P1-09 | `fix/p1-m16-redact-secrets-in-logs` | M-16 |
 | P2-02 | `fix/p2-h1-invariant-culture` | H-1 |
@@ -168,7 +168,7 @@ merge order matters (see the note below) but their *development* does not.
 | P1-10 | ✅ P1-03 *(merged — ready)* | `test/p1-h12-deterministic-timecompute-tests` |
 | P2-01 | ✅ P1-02 + P1-04 (**both merged — ready**) | `refactor/p2-i1-kraken-result-protocol` |
 | P2-03 | P2-02 | `refactor/p2-h2-decimal-money` |
-| P2-08 | ✅ P1-03 + P1-07 (waiting on P1-07) | `refactor/p2-i5-shared-trading-options` |
+| P2-08 | ✅ P1-03 + P1-07 (**both merged — ready**) | `refactor/p2-i5-shared-trading-options` |
 | P2-09 | P1-05 | `ci/p2-workflow-hardening` |
 | P4-01 | — (soft: P3-01) | `refactor/p4-h6-json-state-store` |
 | P4-02 | — (soft: P3-01) | `fix/p4-h7-holiday-cache-resilience` |
@@ -235,7 +235,7 @@ Every finding in REVIEW.md, with its owning plan. Use this to check nothing was 
 | H-7 | P4-02 | M-12 | P4-08 |
 | H-8 | P4-03 | M-13 | P4-08 |
 | H-9 | P2-06 | M-14 | P4-10 |
-| H-10 | P1-07 | M-15 | P4-10 |
+| H-10 ✅ | P1-07 *(merged)* | M-15 | P4-10 |
 | H-11 ✅ | P1-08 *(merged)* | M-16 | P1-09 |
 | H-12 | P1-10 | M-17 | P4-06 |
 | I-1 | P2-01 | M-18 | P2-09 |
@@ -276,7 +276,7 @@ order up front.
 | `docker/example-compose.yaml` | P1-08 ✅, P4-06, P5-02 | P1-08 *(merged)* → P4-06 → P5-02 |
 | `docker/stack.env` | P1-08 ✅, P2-08, P4-10 | P1-08 *(merged)* → P2-08 → P4-10 |
 | `README.md` | P4-05, P5-01, P5-02, P5-03 | P5-01 → P5-02 → P5-03 (P4-05 adds one section; merge whenever) |
-| Both `ServiceCollectionExtension.cs` | P1-07, P2-08, P3-01, P4-03, P5-04 | P1-07 → P2-08 → P3-01 → P4-03 → P5-04 |
+| Both `ServiceCollectionExtension.cs` | P2-08, P3-01, P4-03, P5-04 | P2-08 → P3-01 → P4-03 → P5-04 (P1-07 turned out not to need either file) |
 
 ---
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -113,7 +113,7 @@ the Resolution section what you left out and which plan owns it.
 | P1-04 ✅ | C-5 | Worker loop resilience and backoff *(resolved — #46)* | `fix/p1-c5-worker-loop-resilience` |
 | P1-05 | H-3 | CI: build, test, format gate | `ci/p1-h3-build-test-lint-pipeline` |
 | P1-06 | H-4 | Fix the inert `.dockerignore` and the `secrets.json` copy | `fix/p1-h4-dockerignore-and-secret-copy` |
-| P1-07 | H-10 | Tighten the options validators | `fix/p1-h10-tighten-options-validators` |
+| P1-07 ✅ | H-10 | Tighten the options validators *(resolved — #47)* | `fix/p1-h10-tighten-options-validators` |
 | P1-08 ✅ | H-11 | Remove the committed DB password and published port *(resolved — #44)* | `fix/p1-h11-database-credentials-exposure` |
 | P1-09 | M-16 | Stop logging the API secret | `fix/p1-m16-redact-secrets-in-logs` |
 | P1-10 | H-12 | Deterministic `TimeComputeService` tests | `test/p1-h12-deterministic-timecompute-tests` |

--- a/docs/plans/p1-03-c4-topup-day-clamp-and-state-order.md
+++ b/docs/plans/p1-03-c4-topup-day-clamp-and-state-order.md
@@ -152,4 +152,4 @@ the Dockerfile, but this is now on the path a successful order takes and looks l
 issue #23 (**P4-01** owns that file). `HolidayService.IsHoliday` throws on an empty holiday cache,
 i.e. when the startup fetch failed (**P4-02**).
 
-Follow-ups unblocked: **P1-10**; **P2-08** once P1-07 lands.
+Follow-ups unblocked: **P1-10**; **P2-08** once P1-07 lands — which it has, as PR #47.

--- a/docs/plans/p1-07-h10-tighten-options-validators.md
+++ b/docs/plans/p1-07-h10-tighten-options-validators.md
@@ -97,43 +97,58 @@ What landed:
 - [OrderOptions.cs](../../src/Kbot.DcaService/Options/OrderOptions.cs) — `MinOrderVolume > 0`;
   `AskMultiplier` bounded to the sanity band `[0.5, 1.5]`, because it multiplies the ask *price* and
   the typo `100` for `1.0001` would bid a hundred times the ask; `Fee` bounded to `[0, 100]` as the
-  percentage it is; `CryptoPair` matched against `^[A-Z0-9]{5,12}$`. Every `double` is additionally
+  percentage it is; `CryptoPair` matched against `^[A-Z0-9]{4,16}$`. Every `double` is additionally
   checked with `double.IsFinite`: a `TypeConverter` parses `"Infinity"` and `"NaN"`, and an infinite
   cost is as degenerate as a zero one. P1-02's `Enum.IsDefined(options.Type)` check was already
-  there and was kept as the single copy.
+  there and was kept as the single copy. An `AskMultiplier` below 1 is legal but warned about: it
+  places a resting limit buy under the market, and `SendOrder` neither sets an expiry nor checks for
+  a fill, so the schedule advances on acceptance and DCA can stop silently with the fiat locked in
+  an open order.
 - [WaitOptions.cs](../../src/Kbot.DcaService/Options/WaitOptions.cs) — `MinWaitTime` must be at least
-  one second, `MaxWaitTime` greater than zero, `MinWaitTime <= MaxWaitTime` unchanged. The plan's
-  separate `> TimeSpan.Zero` rule is subsumed by the one-second floor deliberately: two messages for
-  `00:00:00` only make the startup error harder to read, and the tests still prove zero, negative
-  and sub-second values are all rejected. A `MinWaitTime` under five seconds is logged as a warning
-  rather than refused, which is why the validator now takes an `ILogger`.
+  one second, `MaxWaitTime` between zero and seven days, `MinWaitTime <= MaxWaitTime` unchanged. The
+  plan's separate `> TimeSpan.Zero` rule is subsumed by the one-second floor deliberately: two
+  messages for `00:00:00` only make the startup error harder to read, and the tests still prove
+  zero, negative and sub-second values are all rejected. A `MinWaitTime` under five seconds is
+  logged as a warning rather than refused, which is why the validator now takes an `ILogger`. The
+  upper bound on `MaxWaitTime` is there because that value is the ceiling of every `Task.Delay` the
+  loop performs, and `Task.Delay` throws above ~49.7 days from a call site P1-04's catch-all does
+  not cover — the host would stop and Docker would crash-loop it.
 - [BalanceOptions.cs](../../src/Kbot.DcaService/Options/BalanceOptions.cs) — untouched.
   `ReserveFiat >= 0` is correct (reserving nothing is the default) and P1-03 owns
   `DefaultTopupDayOfMonth`.
 - [CultureOptions.cs](../../src/Kbot.Common/Options/CultureOptions.cs) — untouched, as planned;
   M-15's `CultureInfo` / `CountyCode` existence checks belong to P4-10.
-- [appsettings.json](../../src/Kbot.DcaService/appsettings.json) — `OrderOptions`, `BalanceOptions`,
-  `WaitOptions` **and** `CultureOptions` now carry the defaults from `docker/stack.env`.
-  `CryptoPair` deliberately has none: which asset the bot buys must stay a deliberate choice.
+- [appsettings.json](../../src/Kbot.DcaService/appsettings.json) — `OrderOptions`,
+  `BalanceOptions`, `WaitOptions` **and** `CultureOptions` now carry defaults. Every value is the one
+  in `docker/stack.env` **except `MinWaitTime`, which ships `00:00:30` where `stack.env` has
+  `00:00:10`**: the shipped default is deliberately the more conservative of the two, it is the value
+  this plan's scope section specifies, and Compose deployments are unaffected because the environment
+  wins over `appsettings.json`. Nothing in the build compares the two files, so the difference is
+  stated here on purpose rather than left to be discovered. `CryptoPair` deliberately has no default
+  at all: which asset the bot buys must stay a deliberate choice.
 - [DcaWorker.cs](../../src/Kbot.DcaService/DcaWorker.cs) — comment only. P1-04's non-positive-delay
   floor stays as defence in depth; it no longer describes this plan as the missing fix.
 
 `CultureOptions` got defaults although the plan's snippet listed only three sections: the acceptance
 criterion "starting with only `appsettings.json` fails only on `CryptoPair` and `Secrets`" cannot
-hold while the culture section is empty. The cost is that a partial configuration which sets
-`CryptoPair` but omits `CultureOptions` now gets `CHF` silently — and a wrong `Fiat` surfaces as
-"not enough balance", not as a wrong buy.
+hold while the culture section is empty. This weakens an existing fail-fast, so the cost is worth
+stating precisely: an operator who sets `CryptoPair=XBTEUR` but omits `CultureOptions` gets `CHF`.
+`DcaWorker.InvestmentCycle` then looks the balance up by a `Fiat` code that is simply absent from
+Kraken's balance dictionary, logs an error and returns `MaxWaitTime` — an hourly no-op forever, not
+a wrong buy. The direction is fail-safe, but it is silent apart from the log. Whether `Fiat` should
+be a required, deliberate choice like `CryptoPair` belongs to **P2-08**, which unifies both across
+the two services.
 
 Tests: [OptionsValidatorTest.cs](../../test/Kbot.DcaService.Test/OptionsValidatorTest.cs),
 [ShippedDefaultsTest.cs](../../test/Kbot.DcaService.Test/ShippedDefaultsTest.cs) and
-[CultureOptionsValidatorTest.cs](../../test/Kbot.Common.Test/CultureOptionsValidatorTest.cs) — 21
+[CultureOptionsValidatorTest.cs](../../test/Kbot.Common.Test/CultureOptionsValidatorTest.cs) — 25
 tests, the first validator coverage in the repo. One test per rule, each asserting that the
 degenerate value is rejected, that the failure message names the option (the startup error is all an
 operator gets) and that a sane value still starts up. `ShippedDefaultsTest` links the service's real
 `appsettings.json` into the test output and runs it through the real `SetupOptions` wiring, so the
 shipped defaults cannot drift out of validity and an unregistered validator is caught too.
 
-Verified: `dotnet build Kbot.sln -warnaserror` clean, 85 tests pass under the default filter (up
+Verified: `dotnet build Kbot.sln -warnaserror` clean, 89 tests pass under the default filter (up
 from 64), `csharpier check .` clean. The plan's negative-path smoke test fails at startup with
 exactly `Secrets incomplete: ApiKey must be set, ApiSecret must be set` and `OrderOptions
 incomplete: CryptoPair must be set`; the same run with `MinWaitTime=00:00:00`, `AskMultiplier=100`,
@@ -146,5 +161,26 @@ config across both services → **P2-08**; `MailOptions` / `MailSecrets` validat
 
 Neither `ServiceCollectionExtension.cs` needed a change in the end, so P1-07 is off that file's
 conflict list in [ROADMAP.md](../ROADMAP.md) §6.
+
+Review round 1 (independent agent, CHANGES REQUESTED, no must-fixes) changed four things, all of
+them in this PR:
+
+1. `^[A-Z0-9]{5,12}$` → `{4,16}`. Checked against Kraken's live `AssetPairs` list, the original
+   bounds rejected 17 pairs it actually trades — 15 four-character ones (`SUSD`, `AEUR`, …) and
+   `CHILLHOUSEEUR` / `CHILLHOUSEUSD` at thirteen — so a legitimate configuration could not start.
+   The character class survived the same check: no current altname has a lower-case letter or
+   punctuation. The upper bound was also the one bound with no test, which is why the wrong value
+   shipped; both edges are now pinned.
+2. An upper bound on `MaxWaitTime` (see above). The most valuable of the four: it closes the same
+   class of defect this plan exists for, one the plan itself did not name.
+3. The `AskMultiplier < 1` warning (see above). The band stays `[0.5, 1.5]`, because the test
+   project's `appsettings.json` uses `0.5` on purpose so the `LiveExchange` order cannot fill.
+4. The `MinWaitTime` default is documented as deliberately differing from `stack.env` instead of
+   being claimed identical to it, and the `Fiat` failure mode is described correctly (an hourly
+   no-op, not "not enough balance").
+
+Both declared judgement calls were reviewed and kept. Left with their owning plans, as flagged in
+review: a finiteness check on `BalanceOptions.ReserveFiat` and whether `Fiat` should be required
+(**P2-08**), and real pair resolution (**P2-05**).
 
 Follow-ups unblocked: **P2-08**.

--- a/docs/plans/p1-07-h10-tighten-options-validators.md
+++ b/docs/plans/p1-07-h10-tighten-options-validators.md
@@ -2,6 +2,7 @@
 
 |  |  |
 |---|---|
+| **Status** | ✅ **Resolved** — merged into `review-and-fix` via PR #47 |
 | **Findings** | H-10 |
 | **Phase** | 1 — Stop the bleeding |
 | **Branch** | `fix/p1-h10-tighten-options-validators` |
@@ -82,3 +83,68 @@ dotnet test Kbot.sln --filter "TestCategory!=LiveExchange&TestCategory!=LiveApi"
 (cd src/Kbot.DcaService && env -i DOTNET_ENVIRONMENT=Production dotnet run --no-build || true)
 dotnet csharpier check .
 ```
+
+---
+
+## Resolution
+
+Merged into `review-and-fix` from `fix/p1-h10-tighten-options-validators` as PR #47. **H-10 is
+closed**: no degenerate options value starts the DCA service any more, and an omitted `stack.env`
+fails at startup instead of busy-looping against Kraken.
+
+What landed:
+
+- [OrderOptions.cs](../../src/Kbot.DcaService/Options/OrderOptions.cs) — `MinOrderVolume > 0`;
+  `AskMultiplier` bounded to the sanity band `[0.5, 1.5]`, because it multiplies the ask *price* and
+  the typo `100` for `1.0001` would bid a hundred times the ask; `Fee` bounded to `[0, 100]` as the
+  percentage it is; `CryptoPair` matched against `^[A-Z0-9]{5,12}$`. Every `double` is additionally
+  checked with `double.IsFinite`: a `TypeConverter` parses `"Infinity"` and `"NaN"`, and an infinite
+  cost is as degenerate as a zero one. P1-02's `Enum.IsDefined(options.Type)` check was already
+  there and was kept as the single copy.
+- [WaitOptions.cs](../../src/Kbot.DcaService/Options/WaitOptions.cs) — `MinWaitTime` must be at least
+  one second, `MaxWaitTime` greater than zero, `MinWaitTime <= MaxWaitTime` unchanged. The plan's
+  separate `> TimeSpan.Zero` rule is subsumed by the one-second floor deliberately: two messages for
+  `00:00:00` only make the startup error harder to read, and the tests still prove zero, negative
+  and sub-second values are all rejected. A `MinWaitTime` under five seconds is logged as a warning
+  rather than refused, which is why the validator now takes an `ILogger`.
+- [BalanceOptions.cs](../../src/Kbot.DcaService/Options/BalanceOptions.cs) — untouched.
+  `ReserveFiat >= 0` is correct (reserving nothing is the default) and P1-03 owns
+  `DefaultTopupDayOfMonth`.
+- [CultureOptions.cs](../../src/Kbot.Common/Options/CultureOptions.cs) — untouched, as planned;
+  M-15's `CultureInfo` / `CountyCode` existence checks belong to P4-10.
+- [appsettings.json](../../src/Kbot.DcaService/appsettings.json) — `OrderOptions`, `BalanceOptions`,
+  `WaitOptions` **and** `CultureOptions` now carry the defaults from `docker/stack.env`.
+  `CryptoPair` deliberately has none: which asset the bot buys must stay a deliberate choice.
+- [DcaWorker.cs](../../src/Kbot.DcaService/DcaWorker.cs) — comment only. P1-04's non-positive-delay
+  floor stays as defence in depth; it no longer describes this plan as the missing fix.
+
+`CultureOptions` got defaults although the plan's snippet listed only three sections: the acceptance
+criterion "starting with only `appsettings.json` fails only on `CryptoPair` and `Secrets`" cannot
+hold while the culture section is empty. The cost is that a partial configuration which sets
+`CryptoPair` but omits `CultureOptions` now gets `CHF` silently — and a wrong `Fiat` surfaces as
+"not enough balance", not as a wrong buy.
+
+Tests: [OptionsValidatorTest.cs](../../test/Kbot.DcaService.Test/OptionsValidatorTest.cs),
+[ShippedDefaultsTest.cs](../../test/Kbot.DcaService.Test/ShippedDefaultsTest.cs) and
+[CultureOptionsValidatorTest.cs](../../test/Kbot.Common.Test/CultureOptionsValidatorTest.cs) — 21
+tests, the first validator coverage in the repo. One test per rule, each asserting that the
+degenerate value is rejected, that the failure message names the option (the startup error is all an
+operator gets) and that a sane value still starts up. `ShippedDefaultsTest` links the service's real
+`appsettings.json` into the test output and runs it through the real `SetupOptions` wiring, so the
+shipped defaults cannot drift out of validity and an unregistered validator is caught too.
+
+Verified: `dotnet build Kbot.sln -warnaserror` clean, 85 tests pass under the default filter (up
+from 64), `csharpier check .` clean. The plan's negative-path smoke test fails at startup with
+exactly `Secrets incomplete: ApiKey must be set, ApiSecret must be set` and `OrderOptions
+incomplete: CryptoPair must be set`; the same run with `MinWaitTime=00:00:00`, `AskMultiplier=100`,
+`MinOrderVolume=0` and a quoted `CryptoPair` names every one of them.
+
+Deliberately not done: the clamping logic → **P1-03** (merged); the duplicated `CryptoPair` / `Fiat`
+config across both services → **P2-08**; `MailOptions` / `MailSecrets` validators → **P4-07**;
+`CultureInfo` / `CountyCode` validation and `stack.env` quoting → **P4-10**. No tests were added for
+`SecretsValidator`, whose file **P1-09** is editing.
+
+Neither `ServiceCollectionExtension.cs` needed a change in the end, so P1-07 is off that file's
+conflict list in [ROADMAP.md](../ROADMAP.md) §6.
+
+Follow-ups unblocked: **P2-08**.

--- a/docs/plans/p2-08-i5-shared-trading-options.md
+++ b/docs/plans/p2-08-i5-shared-trading-options.md
@@ -6,7 +6,7 @@
 | **Phase** | 2 — Contract & numeric correctness |
 | **Branch** | `refactor/p2-i5-shared-trading-options` |
 | **Effort** | M (~5 h) |
-| **Depends on** | ✅ **P1-03** — merged (#45); **P1-07** (validator tightening) is the one still open |
+| **Depends on** | ✅ **P1-03** — merged (#45); ✅ **P1-07** — merged (#47). Both prerequisites are in: **ready to start** |
 | **Blocks** | — (but **P2-05** consumes it; coordinate whichever lands second) |
 | **Conflict surface** | `src/Kbot.Common/Options/**`, `src/Kbot.DcaService/Options/**`, `src/Kbot.MailService/Options/MailOptions.cs`, both `ServiceCollectionExtension.cs`, `docker/stack.env` (also P4-10; P1-08 is merged — it removed `ConnectionStrings__Kraken` from that file and left `POSTGRES_PASSWORD` as a placeholder) |
 

--- a/docs/plans/p3-03-coverage-gaps.md
+++ b/docs/plans/p3-03-coverage-gaps.md
@@ -32,8 +32,10 @@ the retry loop — 25 s of the suite's runtime spent failing silently.
    with captured real Kraken payloads as fixtures (commit them under `test/Fixtures/`). Include the
    awkward cases: market order with `descr.price = 0` (M-7), unknown status, `stop-loss` type (M-9),
    canonical vs alias pair keys (I-3).
-3. **Options validators** — every rule of all five validators (this is how H-10 survived). Coordinate
-   with **P1-07**, which adds the first ones.
+3. **Options validators** — every rule of all five validators (this is how H-10 survived). **P1-07 is
+   merged** (#47) and covers `OrderOptions`, `WaitOptions`, `BalanceOptions.ReserveFiat` and
+   `CultureOptions`; what is left here is `SecretsValidator`, `MailSecretsValidator` and
+   `MailOptionsValidator`.
 4. **State persistence** — `DcaStateHandler`/`JsonStateStore` load, save, missing directory, corrupt
    JSON, truncated JSON, unreadable file. Note the existing test deletes the wrong file
    (`state.json` vs `state/state.json`) — fix that. Use a per-test temp directory, never the CWD.

--- a/src/Kbot.DcaService/DcaWorker.cs
+++ b/src/Kbot.DcaService/DcaWorker.cs
@@ -98,9 +98,10 @@ public class DcaWorker(
       catch (Exception ex)
       {
         waitTime = backoff.Next();
-        // Never a non-positive delay: a WaitOptions of 00:00:00 passes validation today, and that
-        // would turn a persistent fault into a busy loop against Kraken. Rejecting such a
-        // configuration outright is P1-07.
+        // Never a non-positive delay: WaitOptionsValidator now rejects a MinWaitTime below one
+        // second, so this is defence in depth for any future configuration path that reaches the
+        // loop without passing that validator — a zero delay would turn a persistent fault into a
+        // busy loop against Kraken.
         if (waitTime <= TimeSpan.Zero)
         {
           waitTime = MinimumFailureDelay;

--- a/src/Kbot.DcaService/Options/OrderOptions.cs
+++ b/src/Kbot.DcaService/Options/OrderOptions.cs
@@ -23,7 +23,8 @@ public record OrderOptions
 /// these are all values a human types once, and a typo is far more likely than an exotic-but-valid
 /// setting.
 /// </summary>
-public partial class OrderOptionsValidator : IValidateOptions<OrderOptions>
+public partial class OrderOptionsValidator(ILogger<OrderOptionsValidator> logger)
+  : IValidateOptions<OrderOptions>
 {
   /// <summary>
   /// Sanity band for a <em>price</em> multiplier: the point of it is to sit a hair above or below
@@ -37,6 +38,12 @@ public partial class OrderOptionsValidator : IValidateOptions<OrderOptions>
 
   /// <summary><see cref="OrderOptions.Fee"/> is a percentage, not a fraction.</summary>
   public const double MaxFeePercent = 100;
+
+  /// <summary>
+  /// Below this the limit price sits under the market, which is legal but has a failure mode worth a
+  /// log line — see the warning at the end of <see cref="Validate"/>.
+  /// </summary>
+  public const double AtMarketAskMultiplier = 1;
 
   public ValidateOptionsResult Validate(string? name, OrderOptions options)
   {
@@ -81,7 +88,7 @@ public partial class OrderOptionsValidator : IValidateOptions<OrderOptions>
       // hand through verbatim, lower-case pairs, and a pair accidentally set to a price or a path.
       // It is not a Kraken pair list — resolving pairs against the AssetPairs endpoint is P2-05.
       vor.Add(
-        $"CryptoPair must be 5-12 upper-case letters or digits, e.g. XBTCHF (was "
+        $"CryptoPair must be 4-16 upper-case letters or digits, e.g. XBTCHF (was "
           + $"'{options.CryptoPair}')"
       );
     }
@@ -89,9 +96,27 @@ public partial class OrderOptionsValidator : IValidateOptions<OrderOptions>
     {
       return ValidateOptionsResult.Fail("OrderOptions incomplete: " + string.Join(", ", vor));
     }
+    if (options.AskMultiplier < AtMarketAskMultiplier)
+    {
+      // Legal but a bad idea, so it is warned about rather than refused: the test project's
+      // appsettings.json uses 0.5 on purpose, to keep the LiveExchange order from ever filling.
+      logger.LogWarning(
+        "AskMultiplier is {AskMultiplier}, below the market ask: the limit order may rest unfilled, "
+          + "and the schedule advances anyway (LastInvestmentTime is persisted on acceptance, not on "
+          + "a fill), so DCA can stop silently with the fiat locked in an open order.",
+        options.AskMultiplier
+      );
+    }
     return ValidateOptionsResult.Success;
   }
 
-  [GeneratedRegex("^[A-Z0-9]{5,12}$")]
+  /// <remarks>
+  /// The bounds come from Kraken's live <c>AssetPairs</c> list, not from a guess: the shortest
+  /// altnames it trades are four characters (<c>SUSD</c>, <c>AEUR</c>, …) and the longest thirteen
+  /// (<c>CHILLHOUSEEUR</c>), so <c>{5,12}</c> would have refused to start for 17 real pairs.
+  /// <c>[A-Z0-9]</c> holds for every current altname, which is what still catches the quoted
+  /// <c>"XBTCHF"</c> of M-14, a lower-case pair and <c>XBT/CHF</c>.
+  /// </remarks>
+  [GeneratedRegex("^[A-Z0-9]{4,16}$")]
   private static partial Regex CryptoPairPattern();
 }

--- a/src/Kbot.DcaService/Options/OrderOptions.cs
+++ b/src/Kbot.DcaService/Options/OrderOptions.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Kbot.Common.Enums;
 using Microsoft.Extensions.Options;
 
@@ -14,8 +15,29 @@ public record OrderOptions
   public double InklusiveFeeMultiplier => 1 + Fee / 100;
 }
 
-public class OrderOptionsValidator : IValidateOptions<OrderOptions>
+/// <summary>
+/// Every numeric rule here used to be <c>&gt;= 0</c>, so a zero — the value an omitted environment
+/// variable binds to — was a legal configuration (H-10). A zero <see cref="OrderOptions.AskMultiplier"/>
+/// or <see cref="OrderOptions.MinOrderVolume"/> makes the cost of an order zero, which is the input
+/// that produced the runaway-buy and <c>NaN</c> paths of C-2. The bands are deliberately narrow:
+/// these are all values a human types once, and a typo is far more likely than an exotic-but-valid
+/// setting.
+/// </summary>
+public partial class OrderOptionsValidator : IValidateOptions<OrderOptions>
 {
+  /// <summary>
+  /// Sanity band for a <em>price</em> multiplier: the point of it is to sit a hair above or below
+  /// the current ask, so anything outside ±50 % is a typo — <c>100</c> instead of <c>1.0001</c>
+  /// would bid 100× the ask.
+  /// </summary>
+  public const double MinAskMultiplier = 0.5;
+
+  /// <inheritdoc cref="MinAskMultiplier"/>
+  public const double MaxAskMultiplier = 1.5;
+
+  /// <summary><see cref="OrderOptions.Fee"/> is a percentage, not a fraction.</summary>
+  public const double MaxFeePercent = 100;
+
   public ValidateOptionsResult Validate(string? name, OrderOptions options)
   {
     List<string> vor = [];
@@ -26,21 +48,42 @@ public class OrderOptionsValidator : IValidateOptions<OrderOptions>
         $"Type must be one of {string.Join(", ", Enum.GetNames<OrderType>())} (was {(int)options.Type})"
       );
     }
-    if (options.Fee < 0)
+    if (!double.IsFinite(options.Fee) || options.Fee < 0 || options.Fee > MaxFeePercent)
     {
-      vor.Add("Fee must be greater than or equal to 0");
+      vor.Add($"Fee must be a percentage between 0 and {MaxFeePercent} (was {options.Fee})");
     }
-    if (options.MinOrderVolume < 0)
+    if (!double.IsFinite(options.MinOrderVolume) || options.MinOrderVolume <= 0)
     {
-      vor.Add("MinOrderVolume must be greater than or equal to 0");
+      vor.Add(
+        $"MinOrderVolume must be greater than 0 (was {options.MinOrderVolume}); a zero volume makes "
+          + "the cost of an order zero, which schedules orders as fast as the loop runs"
+      );
     }
-    if (options.AskMultiplier < 0)
+    if (
+      !double.IsFinite(options.AskMultiplier)
+      || options.AskMultiplier < MinAskMultiplier
+      || options.AskMultiplier > MaxAskMultiplier
+    )
     {
-      vor.Add("AskMultiplier must be greater than or equal to 0");
+      vor.Add(
+        $"AskMultiplier must be between {MinAskMultiplier} and {MaxAskMultiplier} (was "
+          + $"{options.AskMultiplier}); it multiplies the ask *price*, so a value outside that band "
+          + "is a typo rather than a strategy"
+      );
     }
     if (string.IsNullOrEmpty(options.CryptoPair))
     {
       vor.Add("CryptoPair must be set");
+    }
+    else if (!CryptoPairPattern().IsMatch(options.CryptoPair))
+    {
+      // Deliberately conservative: it catches the quoted values `docker run --env-file` and systemd
+      // hand through verbatim, lower-case pairs, and a pair accidentally set to a price or a path.
+      // It is not a Kraken pair list — resolving pairs against the AssetPairs endpoint is P2-05.
+      vor.Add(
+        $"CryptoPair must be 5-12 upper-case letters or digits, e.g. XBTCHF (was "
+          + $"'{options.CryptoPair}')"
+      );
     }
     if (vor.Count > 0)
     {
@@ -48,4 +91,7 @@ public class OrderOptionsValidator : IValidateOptions<OrderOptions>
     }
     return ValidateOptionsResult.Success;
   }
+
+  [GeneratedRegex("^[A-Z0-9]{5,12}$")]
+  private static partial Regex CryptoPairPattern();
 }

--- a/src/Kbot.DcaService/Options/WaitOptions.cs
+++ b/src/Kbot.DcaService/Options/WaitOptions.cs
@@ -8,26 +8,65 @@ public record WaitOptions
   public TimeSpan MaxWaitTime { get; init; }
 }
 
-public class WaitOptionsValidator : IValidateOptions<WaitOptions>
+/// <summary>
+/// <see cref="WaitOptions.MinWaitTime"/> is the polling interval of the whole trading loop: every iteration
+/// issues a Kraken <c>Balance</c> and a <c>Ticker</c> call. A zero value used to pass validation —
+/// <c>MinWaitTime = MaxWaitTime = TimeSpan.Zero</c> satisfied every rule — which turned
+/// <c>Task.Delay</c> into a no-op and the loop into a busy loop against a rate-limited API at 100 %
+/// CPU (H-10). Because there was no <c>WaitOptions</c> section in <c>appsettings.json</c> either,
+/// that was what an operator who forgot <c>stack.env</c> got: not a startup failure, a busy loop.
+/// </summary>
+public class WaitOptionsValidator(ILogger<WaitOptionsValidator> logger)
+  : IValidateOptions<WaitOptions>
 {
+  /// <summary>
+  /// The hard floor. Kraken's REST tier allows a small call-rate budget that regenerates over
+  /// seconds, so anything below one second per cycle is a rate-limit ban in the making.
+  /// </summary>
+  public static readonly TimeSpan MinimumPollInterval = TimeSpan.FromSeconds(1);
+
+  /// <summary>
+  /// Below this the configuration is legal but hard on the rate limiter, so it is worth a line in
+  /// the log rather than a refusal to start.
+  /// </summary>
+  public static readonly TimeSpan RecommendedMinimumPollInterval = TimeSpan.FromSeconds(5);
+
   public ValidateOptionsResult Validate(string? name, WaitOptions options)
   {
     List<string> vor = [];
-    if (options.MinWaitTime < TimeSpan.Zero)
+    // One check, not two: "greater than zero" is implied by "at least one second", and emitting
+    // both messages for MinWaitTime = 0 would only make the startup error harder to read.
+    if (options.MinWaitTime < MinimumPollInterval)
     {
-      vor.Add("MinWaitTime must be greater than or equal to 0");
+      vor.Add(
+        $"MinWaitTime must be at least {MinimumPollInterval} (was {options.MinWaitTime}); it is the "
+          + "polling interval of the trading loop, and a zero or sub-second value busy-loops against "
+          + "Kraken's rate limit"
+      );
     }
-    if (options.MaxWaitTime < TimeSpan.Zero)
+    if (options.MaxWaitTime <= TimeSpan.Zero)
     {
-      vor.Add("MaxWaitTime must be greater than or equal to 0");
+      vor.Add($"MaxWaitTime must be greater than 0 (was {options.MaxWaitTime})");
     }
     if (options.MinWaitTime > options.MaxWaitTime)
     {
-      vor.Add("MinWaitTime must be less than or equal to MaxWaitTime");
+      vor.Add(
+        $"MinWaitTime ({options.MinWaitTime}) must be less than or equal to MaxWaitTime "
+          + $"({options.MaxWaitTime})"
+      );
     }
     if (vor.Count > 0)
     {
       return ValidateOptionsResult.Fail("WaitOptions incomplete: " + string.Join(", ", vor));
+    }
+    if (options.MinWaitTime < RecommendedMinimumPollInterval)
+    {
+      logger.LogWarning(
+        "MinWaitTime is {MinWaitTime}, below the recommended {Recommended}: every cycle issues a "
+          + "Kraken Balance and Ticker call, so polling this fast risks a rate-limit lockout.",
+        options.MinWaitTime,
+        RecommendedMinimumPollInterval
+      );
     }
     return ValidateOptionsResult.Success;
   }

--- a/src/Kbot.DcaService/Options/WaitOptions.cs
+++ b/src/Kbot.DcaService/Options/WaitOptions.cs
@@ -31,6 +31,15 @@ public class WaitOptionsValidator(ILogger<WaitOptionsValidator> logger)
   /// </summary>
   public static readonly TimeSpan RecommendedMinimumPollInterval = TimeSpan.FromSeconds(5);
 
+  /// <summary>
+  /// The hard ceiling. <see cref="WaitOptions.MaxWaitTime"/> is what both the wait clamp and the
+  /// failure backoff cap to, and the capped value goes straight into <c>Task.Delay</c>, which throws
+  /// above <see cref="Timer.MaxSupportedTimeout"/> (~49.7 days) — from a call site P1-04's catch-all
+  /// does not cover, so the host would stop and Docker would crash-loop it. A week is already far
+  /// longer than any DCA schedule needs, and it leaves that limit unreachable.
+  /// </summary>
+  public static readonly TimeSpan MaximumWaitTime = TimeSpan.FromDays(7);
+
   public ValidateOptionsResult Validate(string? name, WaitOptions options)
   {
     List<string> vor = [];
@@ -47,6 +56,14 @@ public class WaitOptionsValidator(ILogger<WaitOptionsValidator> logger)
     if (options.MaxWaitTime <= TimeSpan.Zero)
     {
       vor.Add($"MaxWaitTime must be greater than 0 (was {options.MaxWaitTime})");
+    }
+    else if (options.MaxWaitTime > MaximumWaitTime)
+    {
+      vor.Add(
+        $"MaxWaitTime must be at most {MaximumWaitTime} (was {options.MaxWaitTime}); it is the "
+          + "ceiling of every Task.Delay the trading loop performs, and Task.Delay throws above "
+          + "~49.7 days, which would stop the host rather than pause the loop"
+      );
     }
     if (options.MinWaitTime > options.MaxWaitTime)
     {

--- a/src/Kbot.DcaService/appsettings.json
+++ b/src/Kbot.DcaService/appsettings.json
@@ -1,4 +1,23 @@
 {
+  "OrderOptions": {
+    "Type": "Limit",
+    "Fee": 0.4,
+    "MinOrderVolume": 0.00005,
+    "AskMultiplier": 1.00001
+  },
+  "BalanceOptions": {
+    "DefaultTopupDayOfMonth": 26,
+    "ReserveFiat": 0
+  },
+  "WaitOptions": {
+    "MinWaitTime": "00:00:30",
+    "MaxWaitTime": "01:00:00"
+  },
+  "CultureOptions": {
+    "CultureString": "de-CH",
+    "CountyCode": "CH-ZH",
+    "Fiat": "CHF"
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Information",

--- a/test/Kbot.Common.Test/CultureOptionsValidatorTest.cs
+++ b/test/Kbot.Common.Test/CultureOptionsValidatorTest.cs
@@ -1,0 +1,71 @@
+using Kbot.Common.Options;
+
+namespace Kbot.Common.Test;
+
+/// <summary>
+/// H-10 survived because not one of the five options validators had a test. These pin the three
+/// rules <see cref="CultureOptionsValidator"/> has today; checking that
+/// <see cref="CultureOptions.CultureString"/> and <see cref="CultureOptions.CountyCode"/> name a
+/// culture and a region that actually exist — <c>new CultureInfo("\"de-CH\"")</c> throws — is M-15,
+/// owned by P4-10.
+/// </summary>
+[TestClass]
+public class CultureOptionsValidatorTest
+{
+  private static readonly CultureOptions Sane = new()
+  {
+    CultureString = "de-CH",
+    CountyCode = "CH-ZH",
+    Fiat = "CHF",
+  };
+
+  [TestMethod]
+  public void RejectsAMissingCultureString()
+  {
+    AssertFails(Sane with { CultureString = "" }, nameof(CultureOptions.CultureString));
+  }
+
+  [TestMethod]
+  public void RejectsAMissingFiat()
+  {
+    AssertFails(Sane with { Fiat = "" }, nameof(CultureOptions.Fiat));
+  }
+
+  [TestMethod]
+  public void RejectsAMissingCountyCode()
+  {
+    AssertFails(Sane with { CountyCode = "" }, nameof(CultureOptions.CountyCode));
+  }
+
+  [TestMethod]
+  public void RejectsAnEmptySectionNamingEveryMissingOption()
+  {
+    var result = new CultureOptionsValidator().Validate(null, new CultureOptions());
+
+    Assert.IsTrue(result.Failed, "An omitted CultureOptions section must not start up.");
+    // One startup, one complete list: the operator should not have to fix these one restart at a
+    // time.
+    StringAssert.Contains(result.FailureMessage!, nameof(CultureOptions.CultureString));
+    StringAssert.Contains(result.FailureMessage!, nameof(CultureOptions.Fiat));
+    StringAssert.Contains(result.FailureMessage!, nameof(CultureOptions.CountyCode));
+  }
+
+  [TestMethod]
+  public void AcceptsAFullyConfiguredSection()
+  {
+    Assert.IsTrue(new CultureOptionsValidator().Validate(null, Sane).Succeeded);
+  }
+
+  private static void AssertFails(CultureOptions options, string expectedOptionName)
+  {
+    var result = new CultureOptionsValidator().Validate(null, options);
+
+    Assert.IsTrue(result.Failed, $"Should not have started up with {options}.");
+    StringAssert.Contains(
+      result.FailureMessage!,
+      expectedOptionName,
+      $"The startup error is all the operator gets, so it must name {expectedOptionName}. "
+        + $"Got: {result.FailureMessage}"
+    );
+  }
+}

--- a/test/Kbot.DcaService.Test/Kbot.DcaService.Test.csproj
+++ b/test/Kbot.DcaService.Test/Kbot.DcaService.Test.csproj
@@ -23,5 +23,13 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <!--
+      The service's own appsettings.json, so ShippedDefaultsTest can assert that the defaults it
+      ships are complete and valid instead of asserting against a copy that can drift. Linked under
+      a different name: this project already has an appsettings.json of its own in the output.
+    -->
+    <None Include="..\..\src\Kbot.DcaService\appsettings.json" Link="dca-appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/test/Kbot.DcaService.Test/OptionsValidatorTest.cs
+++ b/test/Kbot.DcaService.Test/OptionsValidatorTest.cs
@@ -63,6 +63,42 @@ public class OptionsValidatorTest
     AssertWaitFails(SaneWait with { MaxWaitTime = TimeSpan.FromSeconds(-1) }, "MaxWaitTime");
   }
 
+  /// <summary>
+  /// MaxWaitTime caps every Task.Delay the loop performs, and Task.Delay throws above
+  /// Timer.MaxSupportedTimeout (~49.7 days) from a call site P1-04's catch-all does not cover: the
+  /// host would stop and Docker would crash-loop it. One typo — 100 days for 100 minutes — is
+  /// enough, so the ceiling is validated rather than discovered at runtime.
+  /// </summary>
+  [TestMethod]
+  public void WaitOptions_RejectsAMaxWaitTimeThatTaskDelayCannotHonour()
+  {
+    AssertWaitFails(SaneWait with { MaxWaitTime = TimeSpan.FromDays(100) }, "MaxWaitTime");
+    AssertWaitFails(SaneWait with { MaxWaitTime = TimeSpan.MaxValue }, "MaxWaitTime");
+
+    Assert.IsTrue(
+      Validate(SaneWait with { MaxWaitTime = TimeSpan.FromDays(7) }).Succeeded,
+      "A week is the documented ceiling, so it must be accepted."
+    );
+  }
+
+  /// <summary>
+  /// The bound above exists because of this: everything the validator lets through must be a delay
+  /// the framework can actually wait for.
+  /// </summary>
+  [TestMethod]
+  public async Task WaitOptions_TheAcceptedCeilingIsADelayTaskDelayAccepts()
+  {
+    using var cts = new CancellationTokenSource();
+    await cts.CancelAsync();
+
+    await Assert.ThrowsExactlyAsync<TaskCanceledException>(() =>
+      Task.Delay(WaitOptionsValidator.MaximumWaitTime, cts.Token)
+    );
+    Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+      _ = Task.Delay(TimeSpan.FromDays(100), cts.Token)
+    );
+  }
+
   [TestMethod]
   public void WaitOptions_RejectsAnInvertedRange()
   {
@@ -147,6 +183,31 @@ public class OptionsValidatorTest
     Assert.IsTrue(Validate(SaneOrder with { AskMultiplier = 1.5 }).Succeeded);
   }
 
+  /// <summary>
+  /// A multiplier below 1 is a limit buy under the market. <c>SendOrder</c> sets no expiry and never
+  /// checks for a fill, so the worker persists <c>LastInvestmentTime</c> on Kraken's acceptance of a
+  /// *resting* order: the schedule advances, the fiat stays locked, and DCA stops silently. It stays
+  /// legal — the test project uses 0.5 on purpose — so it is warned about, not refused.
+  /// </summary>
+  [TestMethod]
+  public void OrderOptions_WarnsWithoutFailingBelowTheMarketAsk()
+  {
+    var logger = new CapturingLogger<OrderOptionsValidator>();
+    var validator = new OrderOptionsValidator(logger);
+
+    Assert.IsTrue(validator.Validate(null, SaneOrder with { AskMultiplier = 0.9 }).Succeeded);
+    Assert.AreEqual(1, logger.Warnings.Count, "0.9 places the limit price below the ask.");
+    StringAssert.Contains(logger.Warnings[0], "AskMultiplier");
+
+    logger.Warnings.Clear();
+    Assert.IsTrue(validator.Validate(null, SaneOrder).Succeeded);
+    Assert.AreEqual(
+      0,
+      logger.Warnings.Count,
+      "1.00001 crosses the spread, which is the point of the multiplier: nothing to say."
+    );
+  }
+
   [TestMethod]
   public void OrderOptions_RejectsAFeeOutsideZeroToOneHundredPercent()
   {
@@ -193,6 +254,29 @@ public class OptionsValidatorTest
     );
   }
 
+  /// <summary>
+  /// Both length bounds, at the boundary, against Kraken's live <c>AssetPairs</c> list: the shortest
+  /// altnames it trades are four characters and the longest thirteen. The first version of this rule
+  /// used <c>{5,12}</c> and would have refused to start for 17 real pairs — the cost of an untested
+  /// bound, which is why both edges are pinned here.
+  /// </summary>
+  [TestMethod]
+  public void OrderOptions_AcceptsTheShortestAndLongestPairsKrakenActuallyTrades()
+  {
+    Assert.IsTrue(
+      Validate(SaneOrder with { CryptoPair = "SUSD" }).Succeeded,
+      "Four characters: Kraken's single-letter tickers quoted in USD/EUR."
+    );
+    Assert.IsTrue(
+      Validate(SaneOrder with { CryptoPair = "CHILLHOUSEEUR" }).Succeeded,
+      "Thirteen characters: the longest altname currently listed."
+    );
+    Assert.IsTrue(Validate(SaneOrder with { CryptoPair = new string('X', 16) }).Succeeded);
+
+    AssertOrderFails(SaneOrder with { CryptoPair = "USD" }, "CryptoPair");
+    AssertOrderFails(SaneOrder with { CryptoPair = new string('X', 17) }, "CryptoPair");
+  }
+
   // ------------------------------------------------------------- BalanceOptions
 
   [TestMethod]
@@ -218,7 +302,7 @@ public class OptionsValidatorTest
     new WaitOptionsValidator(NullLogger<WaitOptionsValidator>.Instance).Validate(null, options);
 
   private static ValidateOptionsResult Validate(OrderOptions options) =>
-    new OrderOptionsValidator().Validate(null, options);
+    new OrderOptionsValidator(NullLogger<OrderOptionsValidator>.Instance).Validate(null, options);
 
   private static void AssertWaitFails(WaitOptions options, string expectedOptionName) =>
     AssertFails(Validate(options), expectedOptionName, options.ToString());

--- a/test/Kbot.DcaService.Test/OptionsValidatorTest.cs
+++ b/test/Kbot.DcaService.Test/OptionsValidatorTest.cs
@@ -1,0 +1,271 @@
+using Kbot.Common.Enums;
+using Kbot.DcaService.Options;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Kbot.DcaService.Test;
+
+/// <summary>
+/// H-10: every numeric rule in these validators used to be <c>&gt;= 0</c>, and zero is exactly what
+/// an omitted environment variable binds to. It survived a code review and a release because there
+/// was no validator coverage at all — hence one test per rule here, each asserting that the
+/// degenerate value is rejected, that the failure message names the option (the operator only ever
+/// sees that string), and that a sane value still starts up.
+///
+/// <see cref="BalanceOptions.DefaultTopupDayOfMonth"/> is deliberately absent: P1-03 owns that rule
+/// and covers it in <see cref="TopUpDayClampTest"/>.
+/// </summary>
+[TestClass]
+public class OptionsValidatorTest
+{
+  private static readonly WaitOptions SaneWait = new()
+  {
+    MinWaitTime = TimeSpan.FromSeconds(30),
+    MaxWaitTime = TimeSpan.FromHours(1),
+  };
+
+  private static readonly OrderOptions SaneOrder = new()
+  {
+    Type = OrderType.Limit,
+    Fee = 0.4,
+    MinOrderVolume = 0.00005,
+    AskMultiplier = 1.00001,
+    CryptoPair = "XBTCHF",
+  };
+
+  // ---------------------------------------------------------------- WaitOptions
+
+  /// <summary>
+  /// The finding itself: <c>00:00:00</c> passed all three of the old rules, which made
+  /// <c>Task.Delay</c> a no-op and the trading loop a busy loop against a rate-limited API.
+  /// </summary>
+  [TestMethod]
+  public void WaitOptions_RejectsTheAllZeroConfigurationThatUsedToPass()
+  {
+    AssertWaitFails(
+      new WaitOptions { MinWaitTime = TimeSpan.Zero, MaxWaitTime = TimeSpan.Zero },
+      "MinWaitTime"
+    );
+  }
+
+  [TestMethod]
+  public void WaitOptions_RejectsANegativeOrSubSecondMinWaitTime()
+  {
+    AssertWaitFails(SaneWait with { MinWaitTime = TimeSpan.FromSeconds(-1) }, "MinWaitTime");
+    AssertWaitFails(SaneWait with { MinWaitTime = TimeSpan.FromMilliseconds(500) }, "MinWaitTime");
+  }
+
+  [TestMethod]
+  public void WaitOptions_RejectsANonPositiveMaxWaitTime()
+  {
+    AssertWaitFails(SaneWait with { MaxWaitTime = TimeSpan.Zero }, "MaxWaitTime");
+    AssertWaitFails(SaneWait with { MaxWaitTime = TimeSpan.FromSeconds(-1) }, "MaxWaitTime");
+  }
+
+  [TestMethod]
+  public void WaitOptions_RejectsAnInvertedRange()
+  {
+    var result = Validate(
+      SaneWait with
+      {
+        MinWaitTime = TimeSpan.FromHours(2),
+        MaxWaitTime = TimeSpan.FromHours(1),
+      }
+    );
+
+    Assert.IsTrue(result.Failed);
+    StringAssert.Contains(result.FailureMessage!, "MinWaitTime");
+    StringAssert.Contains(result.FailureMessage!, "MaxWaitTime");
+  }
+
+  [TestMethod]
+  public void WaitOptions_AcceptsASaneRange()
+  {
+    Assert.IsTrue(Validate(SaneWait).Succeeded, "30 s / 1 h is the shipped default.");
+    Assert.IsTrue(
+      Validate(SaneWait with { MinWaitTime = TimeSpan.FromSeconds(1) }).Succeeded,
+      "One second is the documented floor, so it must be accepted."
+    );
+    Assert.IsTrue(
+      Validate(
+        new WaitOptions { MinWaitTime = TimeSpan.FromHours(1), MaxWaitTime = TimeSpan.FromHours(1) }
+      ).Succeeded,
+      "Equal bounds pin the loop to a fixed interval, which is a legitimate configuration."
+    );
+  }
+
+  /// <summary>
+  /// Between the hard floor and the recommended one the service starts, but the operator gets told:
+  /// a one-second poll is legal and still a bad idea.
+  /// </summary>
+  [TestMethod]
+  public void WaitOptions_WarnsWithoutFailingBelowTheRecommendedInterval()
+  {
+    var logger = new CapturingLogger<WaitOptionsValidator>();
+    var validator = new WaitOptionsValidator(logger);
+
+    Assert.IsTrue(
+      validator.Validate(null, SaneWait with { MinWaitTime = TimeSpan.FromSeconds(1) }).Succeeded
+    );
+    Assert.AreEqual(1, logger.Warnings.Count, "One second is below the recommended five.");
+    StringAssert.Contains(logger.Warnings[0], "MinWaitTime");
+
+    logger.Warnings.Clear();
+    Assert.IsTrue(validator.Validate(null, SaneWait).Succeeded);
+    Assert.AreEqual(0, logger.Warnings.Count, "30 s is above the recommendation: nothing to say.");
+  }
+
+  // --------------------------------------------------------------- OrderOptions
+
+  /// <summary>
+  /// A zero volume makes <c>costForVolume</c> zero, which is the input that produced the
+  /// runaway-buy and <c>NaN</c> paths of C-2.
+  /// </summary>
+  [TestMethod]
+  public void OrderOptions_RejectsANonPositiveMinOrderVolume()
+  {
+    AssertOrderFails(SaneOrder with { MinOrderVolume = 0 }, "MinOrderVolume");
+    AssertOrderFails(SaneOrder with { MinOrderVolume = -0.1 }, "MinOrderVolume");
+    Assert.IsTrue(Validate(SaneOrder with { MinOrderVolume = 0.00005 }).Succeeded);
+  }
+
+  [TestMethod]
+  public void OrderOptions_RejectsAnAskMultiplierOutsideTheSanityBand()
+  {
+    AssertOrderFails(SaneOrder with { AskMultiplier = 0 }, "AskMultiplier");
+    // The typo the band exists for: 100 instead of 1.0001 bids a hundred times the ask.
+    AssertOrderFails(SaneOrder with { AskMultiplier = 100 }, "AskMultiplier");
+    AssertOrderFails(SaneOrder with { AskMultiplier = 0.49 }, "AskMultiplier");
+    AssertOrderFails(SaneOrder with { AskMultiplier = 1.51 }, "AskMultiplier");
+
+    Assert.IsTrue(Validate(SaneOrder with { AskMultiplier = 1.00001 }).Succeeded);
+    Assert.IsTrue(
+      Validate(SaneOrder with { AskMultiplier = 0.5 }).Succeeded,
+      "The band is inclusive; the test project's own appsettings.json uses 0.5."
+    );
+    Assert.IsTrue(Validate(SaneOrder with { AskMultiplier = 1.5 }).Succeeded);
+  }
+
+  [TestMethod]
+  public void OrderOptions_RejectsAFeeOutsideZeroToOneHundredPercent()
+  {
+    AssertOrderFails(SaneOrder with { Fee = -0.1 }, "Fee");
+    AssertOrderFails(SaneOrder with { Fee = 100.1 }, "Fee");
+
+    Assert.IsTrue(Validate(SaneOrder with { Fee = 0.4 }).Succeeded);
+    Assert.IsTrue(Validate(SaneOrder with { Fee = 0 }).Succeeded, "A zero fee is legitimate.");
+  }
+
+  [TestMethod]
+  public void OrderOptions_RejectsNonFiniteNumbers()
+  {
+    // A double TypeConverter parses "Infinity" and "NaN", so configuration can carry them.
+    AssertOrderFails(SaneOrder with { Fee = double.NaN }, "Fee");
+    AssertOrderFails(SaneOrder with { MinOrderVolume = double.PositiveInfinity }, "MinOrderVolume");
+    AssertOrderFails(SaneOrder with { AskMultiplier = double.NaN }, "AskMultiplier");
+  }
+
+  [TestMethod]
+  public void OrderOptions_RejectsAnUndefinedOrderType()
+  {
+    AssertOrderFails(SaneOrder with { Type = (OrderType)99 }, "Type");
+
+    Assert.IsTrue(Validate(SaneOrder with { Type = OrderType.Market }).Succeeded);
+    Assert.IsTrue(Validate(SaneOrder with { Type = OrderType.Limit }).Succeeded);
+  }
+
+  [TestMethod]
+  public void OrderOptions_RejectsAPairThatIsNotAPairShape()
+  {
+    AssertOrderFails(SaneOrder with { CryptoPair = "" }, "CryptoPair");
+    // What `docker run --env-file` and systemd EnvironmentFile= hand through for the quoted value
+    // in docker/stack.env. Compose strips the quotes; those two do not (M-14).
+    AssertOrderFails(SaneOrder with { CryptoPair = "\"XBTCHF\"" }, "CryptoPair");
+    AssertOrderFails(SaneOrder with { CryptoPair = "xbtchf" }, "CryptoPair");
+    AssertOrderFails(SaneOrder with { CryptoPair = "XBT" }, "CryptoPair");
+    AssertOrderFails(SaneOrder with { CryptoPair = "XBT/CHF" }, "CryptoPair");
+
+    Assert.IsTrue(Validate(SaneOrder with { CryptoPair = "XBTCHF" }).Succeeded);
+    Assert.IsTrue(
+      Validate(SaneOrder with { CryptoPair = "XXBTZUSD" }).Succeeded,
+      "Kraken's own altname form must stay valid."
+    );
+  }
+
+  // ------------------------------------------------------------- BalanceOptions
+
+  [TestMethod]
+  public void BalanceOptions_RejectsANegativeReserveButAcceptsZero()
+  {
+    var validator = new BalanceOptionsValidator();
+    var sane = new BalanceOptions { DefaultTopupDayOfMonth = 26, ReserveFiat = 0 };
+
+    var rejected = validator.Validate(null, sane with { ReserveFiat = -1 });
+
+    Assert.IsTrue(rejected.Failed);
+    StringAssert.Contains(rejected.FailureMessage!, "ReserveFiat");
+    Assert.IsTrue(
+      validator.Validate(null, sane).Succeeded,
+      "Reserving nothing means spending the whole balance, which is the default and legitimate."
+    );
+    Assert.IsTrue(validator.Validate(null, sane with { ReserveFiat = 250 }).Succeeded);
+  }
+
+  // ---------------------------------------------------------------------- Helpers
+
+  private static ValidateOptionsResult Validate(WaitOptions options) =>
+    new WaitOptionsValidator(NullLogger<WaitOptionsValidator>.Instance).Validate(null, options);
+
+  private static ValidateOptionsResult Validate(OrderOptions options) =>
+    new OrderOptionsValidator().Validate(null, options);
+
+  private static void AssertWaitFails(WaitOptions options, string expectedOptionName) =>
+    AssertFails(Validate(options), expectedOptionName, options.ToString());
+
+  private static void AssertOrderFails(OrderOptions options, string expectedOptionName) =>
+    AssertFails(Validate(options), expectedOptionName, options.ToString());
+
+  private static void AssertFails(
+    ValidateOptionsResult result,
+    string expectedOptionName,
+    string configuration
+  )
+  {
+    Assert.IsTrue(result.Failed, $"Should not have started up with {configuration}.");
+    StringAssert.Contains(
+      result.FailureMessage!,
+      expectedOptionName,
+      $"The startup error is all the operator gets, so it must name {expectedOptionName}. "
+        + $"Got: {result.FailureMessage}"
+    );
+  }
+
+  /// <summary>
+  /// Records the warnings a validator writes. MSTest has no logger substitute and the repo has no
+  /// mocking library, so this is the cheapest way to assert on a log line.
+  /// </summary>
+  private sealed class CapturingLogger<T> : ILogger<T>
+  {
+    public List<string> Warnings { get; } = [];
+
+    public IDisposable? BeginScope<TState>(TState state)
+      where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+      LogLevel logLevel,
+      EventId eventId,
+      TState state,
+      Exception? exception,
+      Func<TState, Exception?, string> formatter
+    )
+    {
+      if (logLevel == LogLevel.Warning)
+      {
+        Warnings.Add(formatter(state, exception));
+      }
+    }
+  }
+}

--- a/test/Kbot.DcaService.Test/ShippedDefaultsTest.cs
+++ b/test/Kbot.DcaService.Test/ShippedDefaultsTest.cs
@@ -1,0 +1,102 @@
+using Kbot.Common.Options;
+using Kbot.DcaService.Options;
+using Kbot.DcaService.Utility;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Kbot.DcaService.Test;
+
+/// <summary>
+/// Runs the real <c>src/Kbot.DcaService/appsettings.json</c> — copied into the output as
+/// <c>dca-appsettings.json</c> by this project's csproj — through the real
+/// <see cref="ServiceCollectionExtension.SetupOptions"/> wiring.
+///
+/// This is the H-10 acceptance criterion as a test: the shipped file used to contain nothing but the
+/// Serilog block, so an operator who forgot <c>stack.env</c> started up with
+/// <c>MinWaitTime = 00:00:00</c> and a busy loop. Now the defaults must be complete <em>and</em>
+/// valid, and the only things a fresh checkout still has to be told are the secrets and which pair
+/// to buy. Asserting it through the container rather than against the validators directly also
+/// covers the registration: a validator nobody registers is a validator nobody runs.
+/// </summary>
+[TestClass]
+public class ShippedDefaultsTest
+{
+  private const string ShippedAppSettings = "dca-appsettings.json";
+
+  [TestMethod]
+  public void ShippedDefaults_AreCompleteAndValidForEverySectionButTheDeliberateOnes()
+  {
+    var provider = Build();
+
+    var wait = provider.GetRequiredService<IOptions<WaitOptions>>().Value;
+    Assert.AreEqual(TimeSpan.FromSeconds(30), wait.MinWaitTime);
+    Assert.AreEqual(TimeSpan.FromHours(1), wait.MaxWaitTime);
+
+    var balance = provider.GetRequiredService<IOptions<BalanceOptions>>().Value;
+    Assert.AreEqual(26, balance.DefaultTopupDayOfMonth);
+    Assert.AreEqual(0, balance.ReserveFiat);
+
+    var culture = provider.GetRequiredService<IOptions<CultureOptions>>().Value;
+    Assert.AreEqual("CHF", culture.Fiat);
+  }
+
+  /// <summary>
+  /// Which asset the bot buys, and with whose keys, must stay a deliberate choice — so these two are
+  /// the only startup failures a checkout with no <c>stack.env</c> may produce.
+  /// </summary>
+  [TestMethod]
+  public void ShippedDefaults_FailOnlyOnTheCryptoPairAndTheSecrets()
+  {
+    var provider = Build();
+
+    var orderFailure = Assert.ThrowsExactly<OptionsValidationException>(() =>
+      _ = provider.GetRequiredService<IOptions<OrderOptions>>().Value
+    );
+    var message = string.Join(" ", orderFailure.Failures);
+    StringAssert.Contains(message, nameof(OrderOptions.CryptoPair));
+    foreach (
+      var defaulted in new[]
+      {
+        nameof(OrderOptions.Type),
+        nameof(OrderOptions.Fee),
+        nameof(OrderOptions.MinOrderVolume),
+        nameof(OrderOptions.AskMultiplier),
+      }
+    )
+    {
+      Assert.IsFalse(
+        message.Contains(defaulted, StringComparison.Ordinal),
+        $"{defaulted} has a shipped default, so it must not appear in the startup error: {message}"
+      );
+    }
+
+    Assert.ThrowsExactly<OptionsValidationException>(
+      () => _ = provider.GetRequiredService<IOptions<Secrets>>().Value,
+      "The Kraken keys are never shipped, so they must be the other startup failure."
+    );
+  }
+
+  [TestMethod]
+  public void ShippedDefaults_PlusACryptoPairValidateCompletely()
+  {
+    var provider = Build(("OrderOptions:CryptoPair", "XBTCHF"));
+
+    var order = provider.GetRequiredService<IOptions<OrderOptions>>().Value;
+
+    Assert.AreEqual("XBTCHF", order.CryptoPair);
+    Assert.AreEqual(1.00001, order.AskMultiplier);
+  }
+
+  private static ServiceProvider Build(params (string Key, string Value)[] overrides)
+  {
+    var configuration = new ConfigurationBuilder()
+      .AddJsonFile(ShippedAppSettings, optional: false)
+      .AddInMemoryCollection(
+        overrides.Select(o => new KeyValuePair<string, string?>(o.Key, o.Value))
+      )
+      .Build();
+
+    return new ServiceCollection().AddLogging().SetupOptions(configuration).BuildServiceProvider();
+  }
+}


### PR DESCRIPTION
Implements [docs/plans/p1-07-h10-tighten-options-validators.md](docs/plans/p1-07-h10-tighten-options-validators.md). **Closes H-10.**

Every numeric rule in the DCA options validators was `>= 0`, and zero is exactly what an omitted
environment variable binds to. `WaitOptions` with `MinWaitTime = MaxWaitTime = 00:00:00` satisfied
all three of its rules, which made `Task.Delay` a no-op and the trading loop a busy loop of Kraken
`Balance` + `Ticker` calls; `MinOrderVolume = 0` or `AskMultiplier = 0` makes the cost of an order
zero, which is the input that produced the runaway-buy and `NaN` paths of C-2. `appsettings.json`
carried nothing but the Serilog block, so forgetting `stack.env` produced the busy loop rather than
a startup failure.

## What changed

- **`WaitOptions`** — `MinWaitTime` at least `00:00:01`; `MaxWaitTime` greater than zero and at most
  seven days; `Min <= Max` unchanged. A `MinWaitTime` below the recommended five seconds is logged as
  a warning instead of refused.
- **`OrderOptions`** — `MinOrderVolume > 0`; `AskMultiplier` bounded to `[0.5, 1.5]` and warned about
  below 1; `Fee` bounded to `[0, 100]`; `CryptoPair` must match `^[A-Z0-9]{4,16}$`; every `double`
  checked for finiteness.
- **`appsettings.json`** — `OrderOptions`, `BalanceOptions`, `WaitOptions` and `CultureOptions` now
  ship defaults. `CryptoPair` deliberately has none.
- **Tests** — 25 new tests, the first validator coverage in the repo.

## Review round 1 — what changed in response

All four should-fixes are addressed; no must-fixes were raised.

1. **`{5,12}` → `{4,16}`** ([c210b6d](../../commit/c210b6d)). The reviewer checked the rule against
   Kraken's live `AssetPairs` list rather than reasoning about it: the original bounds rejected 17
   pairs Kraken really trades — 15 four-character ones (`SUSD`, `AEUR`, …) and `CHILLHOUSEEUR` /
   `CHILLHOUSEUSD` at thirteen — so a legitimate configuration could not start at all. The character
   class is unchanged, confirmed by the same data. The upper bound was also the only bound with no
   test, which is precisely why the wrong value shipped; both edges are pinned now.
2. **An upper bound on `MaxWaitTime`** ([827b215](../../commit/827b215)) — the most valuable of the
   four, and a gap the plan itself did not name. `MaxWaitTime` is the ceiling both
   `ClampToWaitBounds` and `ExponentialBackoff` cap to, and the capped value goes into
   `await Task.Delay(waitTime, stoppingToken)`, which throws above `Timer.MaxSupportedTimeout`
   (~49.7 days) from a call site P1-04's catch-all does not cover — host stopped, Docker crash-loop,
   no startup error naming the cause. Seven days: far more than any DCA schedule needs, and it keeps
   the framework limit out of reach. A paired test asserts the framework behaviour the bound exists
   for, so the two cannot drift.
3. **A warning for `AskMultiplier < 1`** ([c210b6d](../../commit/c210b6d)), the same
   warn-don't-refuse pattern as the sub-five-second `MinWaitTime`. The band stays `[0.5, 1.5]`: the
   test project's `appsettings.json` uses `0.5` on purpose so the `LiveExchange` order cannot fill.
4. **The `MinWaitTime` default is now documented as deliberately different from `stack.env`**
   ([315c424](../../commit/315c424)) rather than claimed identical to it. I kept `00:00:30` — it is
   the value the plan's scope specifies and the more conservative of the two, Compose users are
   unaffected because the environment wins over `appsettings.json`, and correcting the sentence is
   the smaller change. The same commit fixes the `Fiat` failure mode I had described loosely: it is
   not "not enough balance" but a key absent from Kraken's balance dictionary, so the worker logs an
   error and returns `MaxWaitTime` — an hourly no-op forever.

Left with their owning plans, as the review flagged: a finiteness check on
`BalanceOptions.ReserveFiat` and whether `Fiat` should be a required choice like `CryptoPair`
(**P2-08**), and real pair resolution against `AssetPairs` (**P2-05**).

## Choices worth reviewing

- **One `MinWaitTime` check, not two.** The plan lists `> TimeSpan.Zero` and a `>= 1s` floor
  separately; the floor subsumes the former, and emitting two messages for `00:00:00` would only
  make the startup error harder to read. The tests assert that zero, a negative value and 500 ms are
  all rejected.
- **`CultureOptions` got defaults too, though the plan's snippet lists only three sections.** The
  plan's acceptance criterion is *"starting with only `appsettings.json` fails only on `CryptoPair`
  and `Secrets`"*, which cannot hold while `CultureOptions` is empty. The values are the ones already
  in `docker/stack.env`. This weakens an existing fail-fast: an operator who sets `CryptoPair=XBTEUR`
  and forgets `CultureOptions` gets `CHF`, and `InvestmentCycle` then looks up a `Fiat` code Kraken's
  balance dictionary does not contain — an error log and an hourly no-op, fail-safe in direction but
  silent.
- **`CryptoPair` shape check, not a pair list.** `^[A-Z0-9]{4,16}$` still rejects the quoted value
  `docker run --env-file` and systemd `EnvironmentFile=` hand through verbatim (M-14) — Compose, the
  documented deployment, strips those quotes, so this is a new fail-fast for the undocumented paths.
- **Two validators now take an `ILogger`** for their warnings; both are resolved from the container
  as before, and the tests pass `NullLogger` or a small capturing logger.
- **`ShippedDefaultsTest` links the service's real `appsettings.json` into the test output** rather
  than asserting against a copy, so the shipped defaults cannot drift out of validity. It runs them
  through the real `SetupOptions`, which also catches an unregistered validator.
- **P1-04's non-positive-delay floor in `DcaWorker` stays** as defence in depth; only its comment
  changed, since it pointed at this plan as the missing fix.

## Verified

- `dotnet build Kbot.sln -warnaserror` — clean, 0 warnings.
- `dotnet test Kbot.sln` — 89 passed, 0 failed (was 64; +25). `KBOT_ALLOW_LIVE_TRADING` never set.
- `csharpier check .` — clean, 84 files.
- Negative-path smoke test, no configuration at all
  (`env -i DOTNET_ENVIRONMENT=Production`, `HOME` pointed at a nonexistent directory so user secrets
  cannot leak in):
  ```
  Secrets incomplete: ApiKey must be set, ApiSecret must be set
  OrderOptions incomplete: CryptoPair must be set
  ```
  Exactly the two the plan's acceptance criterion allows.
- The same run with the degenerate values from the finding
  (`WaitOptions__MinWaitTime=00:00:00`, `OrderOptions__AskMultiplier=100`,
  `OrderOptions__MinOrderVolume=0`, `OrderOptions__CryptoPair='"XBTCHF"'`) fails at startup naming
  every one of them.
- Round-1 rules end to end: `WaitOptions__MaxWaitTime=100.00:00:00` fails with
  `MaxWaitTime must be at most 7.00:00:00`, and `OrderOptions__CryptoPair=SUSD` — a real Kraken pair
  the first version rejected — no longer produces an `OrderOptions` failure at all.

## Deliberately left out

- The clamping logic itself → **P1-03** (merged). `BalanceOptions.DefaultTopupDayOfMonth` and its
  test are untouched.
- `Enum.IsDefined(options.Type)` was already added by **P1-02**; kept as one copy, now covered by a
  test.
- Unifying the duplicated `CryptoPair` / `Fiat` config across both services → **P2-08**, which this
  merge unblocks. Neither `ServiceCollectionExtension.cs` needed a change, so P1-07 is off that
  file's conflict list.
- `CultureInfo` / `CountyCode` existence validation → **P4-10** (M-15). `stack.env` quoting → also
  **P4-10** (M-14).
- `MailOptions` / `MailSecrets` validators → **P4-07** (M-22); no tests added for them, and none for
  `SecretsValidator`, whose file **P1-09** is editing.
